### PR TITLE
Add support for dark theme & Improve data collection options

### DIFF
--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -103,7 +103,7 @@ import { mdiCog } from '@mdi/js'
 import PullToRefresh from 'pulltorefreshjs'
 import { Component, Vue } from 'vue-property-decorator'
 
-import { SettingsModule } from '@/store/modules/settings'
+import { SettingsModule, ThemeType } from '@/store/modules/settings'
 import { updateAllData } from '@/store/modules/storage'
 import { displaySnackbar, hideSnackbar } from '@/utils/snackbar'
 
@@ -144,6 +144,20 @@ export default class App extends Vue {
     this.isSnackbarDisplayed = true
   }
 
+  themeHandler (event: MediaQueryListEvent): void {
+    // Change Vuetify theme to match system theme
+    if (SettingsModule.theme === ThemeType.System) {
+      this.$vuetify.theme.dark = event.matches
+    }
+
+    // Also set body color to make it possible for browser to style scrollbars
+    setTimeout(() => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      document.getElementsByTagName('body')[0].style.background = getComputedStyle(document.getElementById('app'))['background-color']
+    }, 0)
+  }
+
   swUpdatedHandler (event: Event): void {
     const registration: ServiceWorkerRegistration = (event as CustomEvent).detail
 
@@ -165,6 +179,9 @@ export default class App extends Vue {
     // Event listeners for displaying and hiding snackbars
     document.addEventListener('displaySnackbar', this.snackbarHandler)
     document.addEventListener('hideSnackbar', this.snackbarHandler)
+
+    // Event listener for system theme changes
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', this.themeHandler)
 
     // Event listener for detecting service worker updates
     document.addEventListener('serviceWorkerUpdated', this.swUpdatedHandler, { once: true })
@@ -188,12 +205,20 @@ export default class App extends Vue {
         updateAllData()
       }
     })
+
+    // Also set body color to make it possible for browser to style scrollbars
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    document.getElementsByTagName('body')[0].style.background = getComputedStyle(document.getElementById('app'))['background-color']
   }
 
   destroyed (): void {
     // Remove event listeners for displaying and hiding snackbars
     document.removeEventListener('displaySnackbar', this.snackbarHandler)
     document.removeEventListener('hideSnackbar', this.snackbarHandler)
+
+    // Remove event listener for system theme changes
+    window.matchMedia('(prefers-color-scheme: dark)').removeEventListener('change', this.themeHandler)
 
     // Remove event listener for detecting service worker updates
     document.removeEventListener('serviceWorkerUpdated', this.swUpdatedHandler)

--- a/website/src/components/settings/DataCollectionSelection.vue
+++ b/website/src/components/settings/DataCollectionSelection.vue
@@ -1,0 +1,51 @@
+<template>
+  <v-card width="35rem">
+    <v-toolbar class="text-uppercase" color="#009300" dark>
+      Nastavite zbiranje podatkov
+    </v-toolbar>
+
+    <v-card-text class="text--primary mb-n8">
+      <v-checkbox v-model="performanceCollection" class="mb-n3" color="green" label="Merjenje učinkovitosti" />
+      <v-checkbox v-model="crashesCollection" color="green" label="Zbiranje napak" :disabled="performanceCollection" />
+
+      <p class="text-justify">
+        Aplikacija zbira omejene podatke o brskalniku in uporabi za namene odpravljanja napak in izboljšanja učinkovitosti.
+        Podatki se ne uporabljajo za identfikacijo uporabnikov, oglaševanje ali druge namene.
+      </p>
+    </v-card-text>
+
+    <v-card-actions class="justify-end">
+      <v-btn color="green" text v-on:click=closeDialog>V redu</v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+
+import { SettingsModule } from '@/store/modules/settings'
+
+@Component
+export default class DataCollectionSelection extends Vue {
+  get performanceCollection (): boolean {
+    return SettingsModule.dataCollection.performance
+  }
+
+  set performanceCollection (performance: boolean) {
+    if (performance) this.crashesCollection = true
+    SettingsModule.setDataCollectionPerformance(performance)
+  }
+
+  get crashesCollection (): boolean {
+    return SettingsModule.dataCollection.performance || SettingsModule.dataCollection.crashes
+  }
+
+  set crashesCollection (crashes: boolean) {
+    SettingsModule.setDataCollectionCrashes(crashes)
+  }
+
+  closeDialog (): void {
+    this.$emit('closeDialog')
+  }
+}
+</script>

--- a/website/src/components/settings/ThemeSelection.vue
+++ b/website/src/components/settings/ThemeSelection.vue
@@ -1,25 +1,14 @@
 <template>
   <v-card width="35rem">
     <v-toolbar class="text-uppercase" color="#009300" dark>
-      Izberite barvno temo
+      Nastavite barvno temo
     </v-toolbar>
 
     <v-card-text class="text--primary mb-n12">
       <v-radio-group v-model="themeSelection">
-        <v-radio class="pb-2"
-          :key="0"
-          :value="0"
-          label="Sistemska" />
-
-        <v-radio class="pb-2"
-          :key="1"
-          :value="1"
-          label="Svetla" />
-
-        <v-radio
-          :key="2"
-          :value="2"
-          label="Temna" />
+        <v-radio :key="0" :value="0" class="pb-2" color="green" label="Sistemska" />
+        <v-radio :key="1" :value="1" class="pb-2" color="green" label="Svetla" />
+        <v-radio :key="2" :value="2" color="green" label="Temna" />
       </v-radio-group>
     </v-card-text>
 

--- a/website/src/components/settings/ThemeSelection.vue
+++ b/website/src/components/settings/ThemeSelection.vue
@@ -1,0 +1,77 @@
+<template>
+  <v-card width="35rem">
+    <v-toolbar class="text-uppercase" color="#009300" dark>
+      Izberite barvno temo
+    </v-toolbar>
+
+    <v-card-text class="text--primary mb-n12">
+      <v-radio-group v-model="themeSelection">
+        <v-radio class="pb-2"
+          :key="0"
+          :value="0"
+          label="Sistemska" />
+
+        <v-radio class="pb-2"
+          :key="1"
+          :value="1"
+          label="Svetla" />
+
+        <v-radio
+          :key="2"
+          :value="2"
+          label="Temna" />
+      </v-radio-group>
+    </v-card-text>
+
+    <v-card-actions class="justify-end">
+      <v-btn color="green" text v-on:click=closeDialog>V redu</v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+
+import { SettingsModule, ThemeType } from '@/store/modules/settings'
+
+@Component
+export default class ThemeSelection extends Vue {
+  get themeSelection (): number {
+    switch (SettingsModule.theme) {
+      case ThemeType.Light:
+        return 1
+      case ThemeType.Dark:
+        return 2
+      default:
+        return 0
+    }
+  }
+
+  set themeSelection (theme: number) {
+    switch (theme) {
+      case 1:
+        SettingsModule.setTheme(ThemeType.Light)
+        this.$vuetify.theme.dark = false
+        break
+      case 2:
+        SettingsModule.setTheme(ThemeType.Dark)
+        this.$vuetify.theme.dark = true
+        break
+      default:
+        this.$vuetify.theme.dark = window.matchMedia('(prefers-color-scheme: dark)').matches
+        SettingsModule.setTheme(ThemeType.System)
+    }
+
+    // Also set body color to make it possible for browser to style scrollbars
+    setTimeout(() => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      document.getElementsByTagName('body')[0].style.background = getComputedStyle(document.getElementById('app'))['background-color']
+    }, 0)
+  }
+
+  closeDialog (): void {
+    this.$emit('closeDialog')
+  }
+}
+</script>

--- a/website/src/plugins/vuetify.ts
+++ b/website/src/plugins/vuetify.ts
@@ -2,6 +2,8 @@ import Vue from 'vue'
 import Vuetify from 'vuetify/lib'
 import sl from 'vuetify/src/locale/sl'
 
+import { SettingsModule, ThemeType } from '@/store/modules/settings'
+
 Vue.use(Vuetify)
 
 export default new Vuetify({
@@ -13,6 +15,6 @@ export default new Vuetify({
     iconfont: 'mdiSvg'
   },
   theme: {
-    dark: false
+    dark: (SettingsModule.theme === ThemeType.System && window.matchMedia('(prefers-color-scheme: dark)').matches) || SettingsModule.theme === ThemeType.Dark
   }
 })

--- a/website/src/registerSentry.ts
+++ b/website/src/registerSentry.ts
@@ -12,7 +12,8 @@ import { Integrations } from '@sentry/tracing'
 import router from '@/router'
 import { SettingsModule } from '@/store/modules/settings'
 
-if (process.env.VUE_APP_SENTRY_ENABLED === 'true') {
+// Only load Sentry if it is enabled by build config and user settings
+if (process.env.VUE_APP_SENTRY_ENABLED === 'true' && (SettingsModule.dataCollection.performance || SettingsModule.dataCollection.crashes)) {
   let firstLoad = true
 
   // Custom Vue Router instrumentation for Sentry
@@ -77,7 +78,7 @@ if (process.env.VUE_APP_SENTRY_ENABLED === 'true') {
 
   // Don't add performance monitoring to users who don't want it
   const integrations = []
-  if (!SettingsModule.doNotTrack) {
+  if (SettingsModule.dataCollection.performance) {
     integrations.push(
       new Integrations.BrowserTracing({
         tracingOrigins: process.env.VUE_APP_SENTRY_TRACING_ORIGINS.split(','),
@@ -98,7 +99,7 @@ if (process.env.VUE_APP_SENTRY_ENABLED === 'true') {
     release: releasePrefix + process.env.VUE_APP_VERSION + releaseSuffix,
 
     logErrors: !(process.env.NODE_ENV === 'production'),
-    autoSessionTracking: true,
+    autoSessionTracking: SettingsModule.dataCollection.performance,
     tracingOptions: { trackComponents: true },
 
     integrations: integrations

--- a/website/src/store/modules/settings.ts
+++ b/website/src/store/modules/settings.ts
@@ -21,6 +21,12 @@ export enum LunchType {
   Vegetarian
 }
 
+export enum ThemeType {
+  System,
+  Light,
+  Dark
+}
+
 export interface SelectedEntity {
   type: EntityType;
   data: string[];
@@ -46,7 +52,8 @@ class Settings extends VuexModule {
   enablePullToRefresh = true
   enableUpdateOnLoad = false
   doNotTrack: boolean = navigator.doNotTrack === '1' || !!(navigator as NavigatorGPC).globalPrivacyControl
-  darkTheme: boolean | null = null
+
+  theme: ThemeType = ThemeType.System
 
   @Mutation
   setSelectedEntity (selectedEntity: SelectedEntity): void {
@@ -89,8 +96,8 @@ class Settings extends VuexModule {
   }
 
   @Mutation
-  setDarkTheme (darkTheme: boolean | null): void {
-    this.darkTheme = darkTheme
+  setTheme (theme: ThemeType): void {
+    this.theme = theme
   }
 }
 

--- a/website/src/store/modules/settings.ts
+++ b/website/src/store/modules/settings.ts
@@ -37,6 +37,11 @@ export interface SelectedMenu {
   lunch: LunchType;
 }
 
+export interface DataCollectionConfig {
+  performance: boolean;
+  crashes: boolean;
+}
+
 interface NavigatorGPC extends Navigator {
   globalPrivacyControl: boolean | undefined
 }
@@ -51,7 +56,11 @@ class Settings extends VuexModule {
   showHoursInTimetable = true
   enablePullToRefresh = true
   enableUpdateOnLoad = false
-  doNotTrack: boolean = navigator.doNotTrack === '1' || !!(navigator as NavigatorGPC).globalPrivacyControl
+
+  dataCollection: DataCollectionConfig = {
+    performance: !(navigator.doNotTrack === '1' || !!(navigator as NavigatorGPC).globalPrivacyControl),
+    crashes: true
+  }
 
   theme: ThemeType = ThemeType.System
 
@@ -91,8 +100,18 @@ class Settings extends VuexModule {
   }
 
   @Mutation
-  setDoNotTrack (doNotTrack: boolean): void {
-    this.doNotTrack = doNotTrack
+  setDataCollection (dataCollection: DataCollectionConfig): void {
+    this.dataCollection = dataCollection
+  }
+
+  @Mutation
+  setDataCollectionPerformance (performance: boolean): void {
+    this.dataCollection.performance = performance
+  }
+
+  @Mutation
+  setDataCollectionCrashes (crashes: boolean): void {
+    this.dataCollection.crashes = crashes
   }
 
   @Mutation


### PR DESCRIPTION
This adds support for dark theme. By default, website will rely on `prefers-color-scheme` to get system theme and automatically update website theme when system theme changes. Users can also manually chose light or dark theme in settings.

This also improves data collection options. Users can now enable both crash reporting and performance monitoring, just crash reporting, or nothing. Initial value for performance monitoring will depend on DNT/GPC configuration in browser.