### PR TITLE
Allow classrooms to be unspecified

### DIFF
--- a/API/gimvicurnik/database/__init__.py
+++ b/API/gimvicurnik/database/__init__.py
@@ -30,7 +30,7 @@ class Entity:
             session.query(Lesson, Class.name, Teacher.name, Classroom.name)
             .join(Class)
             .join(Teacher)
-            .join(Classroom)
+            .join(Classroom, isouter=True)
             .order_by(Lesson.day, Lesson.time)
         )
 

--- a/website/src/components/timetable/TimetableDay.vue
+++ b/website/src/components/timetable/TimetableDay.vue
@@ -109,7 +109,7 @@ export default class TimetableDay extends Vue {
             },
             {
               type: 'classroom',
-              contents: displayedLesson.classrooms
+              contents: displayedLesson.classrooms.filter(x => x)
             }
           ]
         })
@@ -133,7 +133,7 @@ export default class TimetableDay extends Vue {
             },
             {
               type: 'classroom',
-              contents: displayedLesson.classrooms
+              contents: displayedLesson.classrooms.filter(x => x)
             }
           ]
         })

--- a/website/src/components/timetable/TimetableWeek.vue
+++ b/website/src/components/timetable/TimetableWeek.vue
@@ -188,9 +188,9 @@ export default class TimetableWeek extends Vue {
               },
               {
                 type: 'classroom',
-                contents: lesson.classrooms
+                contents: lesson.classrooms.filter(x => x)
               }
-            ]
+            ].filter(x => x.contents.length)
           })
         }
 
@@ -209,9 +209,9 @@ export default class TimetableWeek extends Vue {
               },
               {
                 type: 'classroom',
-                contents: lesson.classrooms
+                contents: lesson.classrooms.filter(x => x)
               }
-            ]
+            ].filter(x => x.contents.length)
           })
         }
 


### PR DESCRIPTION
Timetable source has recently changed and now classrooms for most lessons are unspecified. This fixes SQL join to also allow unspecified classrooms and updates the website to handle them correctly.