### PR TITLE
Fix menu updater and API response

### DIFF
--- a/API/gimvicurnik/__init__.py
+++ b/API/gimvicurnik/__init__.py
@@ -338,8 +338,8 @@ class GimVicUrnik:
                 snack = {
                     "normal": snack.normal,
                     "poultry": snack.poultry,
-                    "vegetarian": lunch.vegetarian,
-                    "fruitvegetable": lunch.fruitvegetable,
+                    "vegetarian": snack.vegetarian,
+                    "fruitvegetable": snack.fruitvegetable,
                 }
 
             if lunch:

--- a/API/gimvicurnik/updaters/menu.py
+++ b/API/gimvicurnik/updaters/menu.py
@@ -103,7 +103,8 @@ class MenuUpdater:
 
         # Example: 09-splet-oktober-1-teden-09-M.pdf
         # Another example: 05-splet-februar-3-teden-M-PDF.pdf
-        date = re.search(r"\d+-splet-([a-z]+)-(\d)-teden-?\d*-[MK]-?\d?(?i:-PDF)?\.pdf", url)
+        # Another example: 04-splet-marec-2-teden-04-M-PDF-0.pdf
+        date = re.search(r"\d+-splet-([a-z]+)-(\d)-teden-?\d*-[MK]-?\d?(?i:-PDF)?(?:-\d)?\.pdf", url)
 
         if date:
             year = datetime.datetime.now().year


### PR DESCRIPTION
Date format for menus has changed again. This PR fixes regex to parse it correctly.

There was also wrong variable used when trying to return snack details, causing an error. This fixes variable name to be correct.