### PR TITLE
Improve substitutions parsing and displaying

### DIFF
--- a/API/gimvicurnik/__init__.py
+++ b/API/gimvicurnik/__init__.py
@@ -357,9 +357,7 @@ class GimVicUrnik:
 
         @self.app.route("/documents")
         def _get_documents():
-            query = self.session.query(Document.date, Document.type, Document.url, Document.description).order_by(
-                Document.date
-            )
+            query = self.session.query(Document.date, Document.type, Document.url, Document.description).order_by(Document.date)
 
             config = self.config["sources"]["eclassroom"]["pluginfile"]
             token = self.config["sources"]["eclassroom"]["token"]

--- a/API/gimvicurnik/commands/__init__.py
+++ b/API/gimvicurnik/commands/__init__.py
@@ -73,16 +73,12 @@ def cleanup_database_command():
         for entity in (Substitution, LunchSchedule, SnackMenu, LunchMenu):
             for model in session.query(entity):
                 if (datetime.datetime.now().date() - model.date).days > 14:
-                    logging.getLogger(__name__).info(
-                        "Removing the %s from %s", model.__class__.__name__.lower(), model.date
-                    )
+                    logging.getLogger(__name__).info("Removing the %s from %s", model.__class__.__name__.lower(), model.date)
                     session.delete(model)
 
         # Remove classes/teachers/classrooms without lessons/substitutions
         for entity in (Class, Teacher, Classroom):
             for model in session.query(entity):
                 if len(model.lessons) == 0 and len(model.substitutions) == 0:
-                    logging.getLogger(__name__).info(
-                        "Removing the unused %s %s", model.__class__.__name__.lower(), model.name
-                    )
+                    logging.getLogger(__name__).info("Removing the unused %s %s", model.__class__.__name__.lower(), model.name)
                     session.delete(model)

--- a/API/gimvicurnik/database/__init__.py
+++ b/API/gimvicurnik/database/__init__.py
@@ -56,9 +56,7 @@ class Entity:
         classroom = aliased(Classroom)
 
         query = (
-            session.query(
-                Substitution, Class.name, original_teacher.name, original_classroom.name, teacher.name, classroom.name
-            )
+            session.query(Substitution, Class.name, original_teacher.name, original_classroom.name, teacher.name, classroom.name)
             .join(Class)
             .join(original_teacher, Substitution.original_teacher_id == original_teacher.id, isouter=True)
             .join(original_classroom, Substitution.original_classroom_id == original_classroom.id, isouter=True)

--- a/API/gimvicurnik/updaters/eclassroom.py
+++ b/API/gimvicurnik/updaters/eclassroom.py
@@ -65,7 +65,7 @@ class EClassroomUpdater:
             if object["course"] != self.course:
                 continue
 
-            yield (object["name"], object["externalurl"], datetime.datetime.fromtimestamp(object["timemodified"]))
+            yield object["name"], object["externalurl"], datetime.datetime.fromtimestamp(object["timemodified"])
 
     def _get_documents(self):
         params = {
@@ -112,9 +112,7 @@ class EClassroomUpdater:
     @with_span(op="document", pass_span=True)
     def _store_generic(self, name, url, date, urltype, span):
         # Add or skip new generic document
-        model, created = get_or_create(
-            session=self.session, model=Document, date=date, type=urltype, url=url, description=name
-        )
+        model, created = get_or_create(session=self.session, model=Document, date=date, type=urltype, url=url, description=name)
 
         span.description = model.url
         span.set_tag("document.url", model.url)
@@ -155,9 +153,7 @@ class EClassroomUpdater:
 
             return
 
-        date = datetime.datetime.strptime(
-            re.search(r"_obvestila_(.+).pdf", url, re.IGNORECASE).group(1), "%d._%m._%Y"
-        ).date()
+        date = datetime.datetime.strptime(re.search(r"_obvestila_(.+).pdf", url, re.IGNORECASE).group(1), "%d._%m._%Y").date()
         day = date.isoweekday()
 
         # Save content to temporary file
@@ -234,6 +230,7 @@ class EClassroomUpdater:
                             teacher = "KrapežM"
                     classroom = original_classroom
 
+                    # fmt: off
                     for class_ in classes:
                         substitutions.append(
                             {
@@ -241,23 +238,14 @@ class EClassroomUpdater:
                                 "day": day,
                                 "time": time,
                                 "subject": subject,
-                                "original_teacher_id": get_or_create(
-                                    self.session, model=Teacher, name=original_teacher
-                                )[0].id,
-                                "original_classroom_id": get_or_create(
-                                    self.session, model=Classroom, name=original_classroom
-                                )[0].id
-                                if original_classroom
-                                else None,
+                                "original_teacher_id": get_or_create(self.session, model=Teacher, name=original_teacher)[0].id,
+                                "original_classroom_id": get_or_create(self.session, model=Classroom, name=original_classroom)[0].id if original_classroom else None,
                                 "class_id": get_or_create(self.session, model=Class, name=class_)[0].id,
-                                "teacher_id": get_or_create(self.session, model=Teacher, name=teacher)[0].id
-                                if teacher != "/"
-                                else None,
-                                "classroom_id": get_or_create(self.session, model=Classroom, name=classroom)[0].id
-                                if classroom
-                                else None,
+                                "teacher_id": get_or_create(self.session, model=Teacher, name=teacher)[0].id if teacher != "/" else None,
+                                "classroom_id": get_or_create(self.session, model=Classroom, name=classroom)[0].id if classroom else None,
                             }
                         )
+                    # fmt: on
 
                 elif parser_type == "lesson-change":
                     time = row[1][:-1]
@@ -288,6 +276,7 @@ class EClassroomUpdater:
                             teacher = "KrapežM"
                     classroom = original_classroom
 
+                    # fmt: off
                     for class_ in classes:
                         substitutions.append(
                             {
@@ -295,25 +284,14 @@ class EClassroomUpdater:
                                 "day": day,
                                 "time": time,
                                 "subject": subject if subject != "X" else None,
-                                "original_teacher_id": get_or_create(
-                                    self.session, model=Teacher, name=original_teacher
-                                )[0].id
-                                if original_teacher != "X"
-                                else None,
-                                "original_classroom_id": get_or_create(
-                                    self.session, model=Classroom, name=original_classroom
-                                )[0].id
-                                if original_classroom != "/"
-                                else None,
+                                "original_teacher_id": get_or_create(self.session, model=Teacher, name=original_teacher)[0].id if original_teacher != "X" else None,
+                                "original_classroom_id": get_or_create(self.session, model=Classroom, name=original_classroom)[0].id if original_classroom != "/" else None,
                                 "class_id": get_or_create(self.session, model=Class, name=class_)[0].id,
-                                "teacher_id": get_or_create(self.session, model=Teacher, name=teacher)[0].id
-                                if teacher != "X"
-                                else None,
-                                "classroom_id": get_or_create(self.session, model=Classroom, name=classroom)[0].id
-                                if classroom != "/"
-                                else None,
+                                "teacher_id": get_or_create(self.session, model=Teacher, name=teacher)[0].id if teacher != "X" else None,
+                                "classroom_id": get_or_create(self.session, model=Classroom, name=classroom)[0].id if classroom != "/" else None,
                             }
                         )
+                    # fmt: on
 
                 elif parser_type == "classroom-change":
                     time = row[1][:-1]
@@ -337,6 +315,7 @@ class EClassroomUpdater:
                     teacher = original_teacher
                     classroom = row[5]
 
+                    # fmt: off
                     for class_ in classes:
                         for original_classroom in original_classrooms:
                             substitutions.append(
@@ -345,17 +324,14 @@ class EClassroomUpdater:
                                     "day": day,
                                     "time": time,
                                     "subject": subject,
-                                    "original_teacher_id": get_or_create(
-                                        self.session, model=Teacher, name=original_teacher
-                                    )[0].id,
-                                    "original_classroom_id": get_or_create(
-                                        self.session, model=Classroom, name=original_classroom
-                                    )[0].id,
+                                    "original_teacher_id": get_or_create(self.session, model=Teacher, name=original_teacher)[0].id,
+                                    "original_classroom_id": get_or_create(self.session, model=Classroom, name=original_classroom)[0].id,
                                     "class_id": get_or_create(self.session, model=Class, name=class_)[0].id,
                                     "teacher_id": get_or_create(self.session, model=Teacher, name=teacher)[0].id,
                                     "classroom_id": get_or_create(self.session, model=Classroom, name=classroom)[0].id,
                                 }
                             )
+                    # fmt: on
 
         # Store substitutions in database
         for substitution in substitutions:
@@ -462,9 +438,7 @@ class EClassroomUpdater:
 
         # Get lunch schedule for the same date if schedule was updated and URL has changed
         if not document:
-            document = (
-                self.session.query(Document).filter(Document.type == "lunch-schedule", Document.date == date).first()
-            )
+            document = self.session.query(Document).filter(Document.type == "lunch-schedule", Document.date == date).first()
 
         # Update or create a document
         if not document:
@@ -512,13 +486,8 @@ class EClassroomUpdater:
             "dec": 12,
         }
 
-        search = re.search(
-            r"\/delitevKosila-([1-9][0-9]+)-[0-9][1-9]+-([a-z]+)([1-9][0-9]+)(?:-popravek-[a-z0-9]+)?\.pdf$", url
-        )
-
-        return datetime.date(
-            year=int(search.group(3)), month=month_to_number[search.group(2)], day=int(search.group(1))
-        )
+        search = re.search(r"\/delitevKosila-([1-9][0-9]+)-[0-9][1-9]+-([a-z]+)([1-9][0-9]+)(?:-popravek-[a-z0-9]+)?\.pdf$", url)
+        return datetime.date(year=int(search.group(3)), month=month_to_number[search.group(2)], day=int(search.group(1)))
 
     def _parse_daily_lunch_schedule(self, date, tables):
         schedule = []

--- a/API/gimvicurnik/updaters/eclassroom.py
+++ b/API/gimvicurnik/updaters/eclassroom.py
@@ -299,26 +299,10 @@ class EClassroomUpdater:
                     # fmt: on
 
         # Store substitutions in database
-        for substitution in substitutions:
-            model = (
-                self.session.query(Substitution)
-                .filter(
-                    Substitution.date == substitution["date"],
-                    Substitution.time == substitution["time"],
-                    Substitution.original_teacher_id == substitution["original_teacher_id"],
-                    Substitution.class_id == substitution["class_id"],
-                )
-                .first()
-            )
+        substitutions = [dict(element) for element in {tuple(substitution.items()) for substitution in substitutions}]
 
-            # Update or create a substitution
-            if not model:
-                model = Substitution()
-
-            for key in substitution:
-                setattr(model, key, substitution[key])
-
-            self.session.add(model)
+        self.session.query(Substitution).filter(Substitution.date == date).delete()
+        self.session.bulk_insert_mappings(Substitution, substitutions)
 
         # Update or create a document
         if not document:

--- a/API/gimvicurnik/updaters/eclassroom.py
+++ b/API/gimvicurnik/updaters/eclassroom.py
@@ -446,6 +446,23 @@ class EClassroomUpdater:
             elif "Marjetka" in name:
                 return "KrapežM"
 
+        # Special case: Teachers with multiple surnames
+        teachers = {
+            "Jereb": "Batagelj",
+            "Gresl": "Černe",
+            "Tehovnik": "Glaser",
+            "Merhar": "Kariž",
+            "Erbežnik": "Mihelič",
+            "Zelič": "Ocvirk",
+            "Osole": "Pikl",
+            "Vičar": "Potočnik",
+            "Završnik": "Ražen",
+            "Vahtar": "Rudolf",
+            "Stjepić": "Šajn",
+        }
+        if name.split()[0] in teachers:
+            return teachers[name.split()[0]]
+
         # Use only surname and replace ć with č
         return name.split()[0].replace("ć", "č")
 

--- a/API/gimvicurnik/updaters/menu.py
+++ b/API/gimvicurnik/updaters/menu.py
@@ -98,9 +98,7 @@ class MenuUpdater:
         date = re.search(r"(?:KOSILO|MALICA)-(\d+)([a-z]+)-\d+[a-z]+-(\d+)(?i:-PDF)?\.[a-z]+", url)
 
         if date:
-            return datetime.date(
-                year=int(date.group(3)), month=short_month_to_number[date.group(2)], day=int(date.group(1))
-            )
+            return datetime.date(year=int(date.group(3)), month=short_month_to_number[date.group(2)], day=int(date.group(1)))
 
         # Example: 09-splet-oktober-1-teden-09-M.pdf
         # Another example: 05-splet-februar-3-teden-M-PDF.pdf

--- a/API/gimvicurnik/updaters/timetable.py
+++ b/API/gimvicurnik/updaters/timetable.py
@@ -62,9 +62,7 @@ class TimetableUpdater:
                 "subject": lesson[3] if lesson[3] else None,
                 "class_id": get_or_create(self.session, model=Class, name=lesson[1])[0].id if lesson[1] else None,
                 "teacher_id": get_or_create(self.session, model=Teacher, name=lesson[2])[0].id if lesson[2] else None,
-                "classroom_id": get_or_create(self.session, model=Classroom, name=lesson[4])[0].id
-                if lesson[4]
-                else None,
+                "classroom_id": get_or_create(self.session, model=Classroom, name=lesson[4])[0].id if lesson[4] else None,
             }
             for _, lesson in lessons.items()
         ]

--- a/API/pyproject.toml
+++ b/API/pyproject.toml
@@ -59,7 +59,7 @@ flake8-bugbear = "^20.11.1"
 sentry = ["sentry-sdk"]
 
 [tool.flakehell]
-max_line_length = 120
+max_line_length = 130
 format = "grouped"
 
 [tool.flakehell.plugins]
@@ -70,7 +70,7 @@ format = "grouped"
 "pyflakes" = ["+*", "-F401"]
 
 [tool.black]
-line-length = 120
+line-length = 130
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -137,6 +137,8 @@ export default class App extends Vue {
       return
     }
 
+    if (this.isSnackbarDisplayed) return
+
     this.snackbarMessage = (event as CustomEvent).detail.message
     this.snackbarButton = (event as CustomEvent).detail?.button
     this.snackbarAction = (event as CustomEvent).detail?.action

--- a/website/src/store/modules/settings.ts
+++ b/website/src/store/modules/settings.ts
@@ -55,7 +55,7 @@ class Settings extends VuexModule {
   showLinksInTimetable = true
   showHoursInTimetable = true
   enablePullToRefresh = true
-  enableUpdateOnLoad = false
+  enableUpdateOnLoad = true
 
   dataCollection: DataCollectionConfig = {
     performance: !(navigator.doNotTrack === '1' || !!(navigator as NavigatorGPC).globalPrivacyControl),

--- a/website/src/store/modules/storage.ts
+++ b/website/src/store/modules/storage.ts
@@ -95,13 +95,15 @@ class Storage extends VuexModule {
   emptyClassrooms: Lesson[] | null = null
   documents: Document[] | null = null
 
-  get substitutions (): Map<string, Substitution> {
+  get substitutions (): Map<string, Substitution[]> {
     const substitutionMap = new Map()
 
     // Add keys to substitutions so they can be found more quickly
     for (const substitution of (this._substitutions?.flat() || [])) {
       if (!substitution) continue
-      substitutionMap.set(getSubstitutionId(substitution), substitution)
+
+      const substitutionId = getSubstitutionId(substitution)
+      substitutionMap.set(substitutionId, (substitutionMap.get(substitutionId) || []).concat(substitution))
     }
 
     return substitutionMap

--- a/website/src/utils/timetable.ts
+++ b/website/src/utils/timetable.ts
@@ -3,7 +3,7 @@ import { DisplayedLesson, getLessonId, StorageModule } from '@/store/modules/sto
 
 export function getTimetableData (entity: SelectedEntity | null, days: number[]): Map<number, Map<number, DisplayedLesson>> {
   const dataSource = entity?.type !== EntityType.EmptyClassrooms ? StorageModule.timetable : StorageModule.emptyClassrooms
-  const substitutionsSource = entity?.type === EntityType.Class ? StorageModule.substitutions : new Map()
+  const substitutionsSource = entity?.type === EntityType.Class ? new Map(StorageModule.substitutions) : new Map()
 
   const displayedLessons: Map<number, Map<number, DisplayedLesson>> = new Map()
   for (const lesson of dataSource || []) {
@@ -41,20 +41,21 @@ export function getTimetableData (entity: SelectedEntity | null, days: number[])
     // Add substitution if it exists
     // Currently only works for classes
     if (SettingsModule.showSubstitutions && substitutionsSource.has(getLessonId(lesson))) {
-      const substitution = substitutionsSource.get(getLessonId(lesson))
+      for (const substitution of substitutionsSource.get(getLessonId(lesson))) {
+        if (substitution.subject) {
+          /* eslint-disable no-unused-expressions */
+          displayedLessons.get(lesson.day)?.get(lesson.time)?.subjects.push(substitution.subject)
+          displayedLessons.get(lesson.day)?.get(lesson.time)?.classes.push(substitution.class)
+          displayedLessons.get(lesson.day)?.get(lesson.time)?.teachers.push(substitution.teacher)
+          displayedLessons.get(lesson.day)?.get(lesson.time)?.classrooms.push(substitution.classroom)
+          /* eslint-enable */
+        }
 
-      if (substitution.subject) {
-        /* eslint-disable no-unused-expressions */
-        displayedLessons.get(lesson.day)?.get(lesson.time)?.subjects.push(substitution.subject)
-        displayedLessons.get(lesson.day)?.get(lesson.time)?.classes.push(substitution.class)
-        displayedLessons.get(lesson.day)?.get(lesson.time)?.teachers.push(substitution.teacher)
-        displayedLessons.get(lesson.day)?.get(lesson.time)?.classrooms.push(substitution.classroom)
-        /* eslint-enable */
+        const displayedLesson = displayedLessons.get(lesson.day)?.get(lesson.time)
+        if (displayedLesson) displayedLesson.substitution = true
       }
 
-      const displayedLesson = displayedLessons.get(lesson.day)?.get(lesson.time)
-      if (displayedLesson) displayedLesson.substitution = true
-
+      substitutionsSource.delete(getLessonId(lesson))
       continue
     }
 
@@ -64,6 +65,49 @@ export function getTimetableData (entity: SelectedEntity | null, days: number[])
     displayedLessons.get(lesson.day)?.get(lesson.time)?.teachers.push(lesson.teacher)
     displayedLessons.get(lesson.day)?.get(lesson.time)?.classrooms.push(lesson.classroom)
     /* eslint-enable */
+  }
+
+  // Add substitutions for new lessons
+  if (SettingsModule.showSubstitutions) {
+    for (const substitutionList of substitutionsSource.values()) {
+      // Check if class/teacher/classroom is correct
+      let isCorrectEntity = false
+      if (entity?.type === EntityType.Class) {
+        isCorrectEntity = entity.data.includes(substitutionList[0].class)
+      } else if (entity?.type === EntityType.Teacher) {
+        isCorrectEntity = entity.data.includes(substitutionList[0].teacher)
+      } else if (entity?.type === EntityType.Classroom) {
+        isCorrectEntity = entity.data.includes(substitutionList[0].classroom)
+      } else if (entity?.type === EntityType.EmptyClassrooms) isCorrectEntity = true
+
+      if (!days.includes(substitutionList[0].day) || !isCorrectEntity) continue
+
+      // Convert data into structured format
+      if (!displayedLessons.has(substitutionList[0].day)) {
+        displayedLessons.set(substitutionList[0].day, new Map())
+      }
+
+      if (!displayedLessons.get(substitutionList[0].day)?.has(substitutionList[0].time)) {
+        displayedLessons.get(substitutionList[0].day)?.set(substitutionList[0].time, {
+          day: substitutionList[0].day,
+          time: substitutionList[0].time,
+          subjects: [],
+          classes: [],
+          teachers: [],
+          classrooms: [],
+          substitution: true
+        })
+      }
+
+      for (const substitution of substitutionList) {
+        /* eslint-disable no-unused-expressions */
+        displayedLessons.get(substitution.day)?.get(substitution.time)?.subjects.push(substitution.subject)
+        displayedLessons.get(substitution.day)?.get(substitution.time)?.classes.push(substitution.class)
+        displayedLessons.get(substitution.day)?.get(substitution.time)?.teachers.push(substitution.teacher)
+        displayedLessons.get(substitution.day)?.get(substitution.time)?.classrooms.push(substitution.classroom)
+        /* eslint-enable */
+      }
+    }
   }
 
   return displayedLessons


### PR DESCRIPTION
This adds some fixes for handling and displaying substitutions:

* Substitutions with empty/unknown teachers and classrooms will now be parsed and stored properly.
* Substitutions with teachers with multiple surnames will now use correct surnames.
* Substitutions with subclasses will now store and display correctly.
* Substitutions that add new lessons will now be displayed correctly.

There are also some other improvements:

* Allowed Python file length has been increased a bit and files were formatted.
* New snackbars won't overwrite existing ones.
* Update on load is now enabled by default.