### PR TITLE
Add another route params check to prevent race condition

### DIFF
--- a/website/src/views/Timetable.vue
+++ b/website/src/views/Timetable.vue
@@ -97,6 +97,9 @@ export default class Timetable extends Vue {
       // Update lists if needed
       if (!this.$route.params.skipListUpdate) await StorageModule.updateLists()
 
+      // User is already on another page
+      if (!this.$route.params.type || !this.$route.params.value) return
+
       const type = this.$route.params.type
       const data = this.$route.params.value.split(',')
 


### PR DESCRIPTION
Sometimes list update takes longer, so if user navigates to another route, `this.$route.params` will be undefined and cause error. This adds another check for `this.$route.params` after lists are updated to prevent this.