### PR TITLE
Return UTC midnight for get Monday function

### DIFF
--- a/website/src/utils/days.ts
+++ b/website/src/utils/days.ts
@@ -15,7 +15,7 @@ export function getMonday (date: Date): Date {
   if (day === 6) diff = date.getDate() + 2
   if (day === 0) diff = date.getDate() + 1
 
-  return new Date(date.setDate(diff))
+  return new Date(Date.UTC(date.getFullYear(), date.getMonth(), diff))
 }
 
 export function getWeekDays (monday: Date): Date[] {


### PR DESCRIPTION
Because of DST switch, `getMonday` returned midnight at incorrect time, causing it to instead be parsed as Sunday. This fixes `getMonday` to always return date at UTC midnight.