### PR TITLE
Fix lunch schedule date parser

### DIFF
--- a/API/gimvicurnik/updaters/eclassroom.py
+++ b/API/gimvicurnik/updaters/eclassroom.py
@@ -413,7 +413,8 @@ class EClassroomUpdater:
 
         # Daily lunch schedule format, used starting with March 2021
         # Example: delitevKosila-mar9-2021-TOR-objava-PDF-0.pdf
-        elif re.search(r"\/delitevKosila-[a-z0-9]+-[0-9]+-[A-Z]{3}-objava.*\.pdf$", url):
+        # Example: delitevKosila-1sept2021-SRE-objava-PDF.pdf
+        elif re.search(r"\/delitevKosila-[a-z0-9]+(?:-[0-9]+)?-[A-Z]{3}-objava.*\.pdf$", url):
             date = self._get_daily_lunch_schedule_date(name, url)
             self._parse_daily_lunch_schedule(date, tables)
 

--- a/website/vue.config.js
+++ b/website/vue.config.js
@@ -10,11 +10,10 @@ module.exports = {
 
   pwa: {
     name: process.env.VUE_APP_TITLE,
+    manifestPath: 'site.webmanifest',
 
     themeColor: '#007300',
     msTileColor: '#007300',
-
-    manifestPath: 'site.webmanifest',
 
     workboxOptions: {
       navigateFallback: '/index.html',
@@ -27,6 +26,12 @@ module.exports = {
       description: process.env.VUE_APP_DESCRIPTION,
       categories: process.env.VUE_APP_CATEGORIES.split(','),
       keywords: process.env.VUE_APP_KEYWORDS.split(','),
+
+      theme_color: '#007300',
+      background_color: '#ffffff',
+
+      scope: '/',
+      start_url: '/',
 
       shortcuts: [
         {
@@ -56,10 +61,7 @@ module.exports = {
             sizes: '192x192'
           }]
         }
-      ],
-
-      theme_color: '#007300',
-      background_color: '#ffffff'
+      ]
     }
   },
 


### PR DESCRIPTION
This fixes the lunch schedule date parser to also support a slightly different URL format, used starting with September 2021. This also fixes the web app manifest scope and start URL.