### PR TITLE
Fix lunch schedule and menu updaters

### DIFF
--- a/API/gimvicurnik/updaters/eclassroom.py
+++ b/API/gimvicurnik/updaters/eclassroom.py
@@ -540,6 +540,9 @@ class EClassroomUpdater:
                     row[0] = times[0]
                     table[index + 1][0] = times[1]
 
+                # Handle different time formats
+                row[0] = row[0].strip().replace(".", ":")
+
                 # Skip header
                 if row[0] and "ura" in row[0]:
                     continue
@@ -549,7 +552,7 @@ class EClassroomUpdater:
                     continue
 
                 is_time_valid = row[0] and row[0].strip() != "do"
-                time = datetime.datetime.strptime(row[0].strip(), "%H:%M").time() if is_time_valid else last_hour
+                time = datetime.datetime.strptime(row[0], "%H:%M").time() if is_time_valid else last_hour
                 last_hour = time
 
                 notes = row[1].strip() if row[0] else last_notes

--- a/API/gimvicurnik/updaters/menu.py
+++ b/API/gimvicurnik/updaters/menu.py
@@ -178,7 +178,10 @@ class MenuUpdater:
 
             # Parse tables into menus and store them
             for table in tables:
-                for row in table[1::2]:
+                for row in table:
+                    if "NV in N" in row[1]:
+                        continue
+
                     current = date + datetime.timedelta(days=days)
                     days += 1
 
@@ -328,7 +331,10 @@ class MenuUpdater:
 
             # Parse tables into menus and store them
             for table in tables:
-                for row in table[1::2]:
+                for row in table:
+                    if "N KOSILO" in row[1]:
+                        continue
+
                     current = date + datetime.timedelta(days=days)
                     days += 1
 


### PR DESCRIPTION
Lunch schedule times are sometimes written in "%H.%M" format. This PR fixes the lunch schedule updater to convert such cells to standard "%H:%M" format and parse them correctly.

This PR also fixes the menu updater to not assume header positions and instead check if the row contains a header and skip it.