### PR TITLE
Updaters and routes fixes

### DIFF
--- a/API/gimvicurnik/database/__init__.py
+++ b/API/gimvicurnik/database/__init__.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     Index,
     Integer,
     SmallInteger,
+    String,
     Text,
     Time,
     func,
@@ -66,7 +67,7 @@ class Document(Base):
     title = Column(Text, nullable=True)
     hash = Column(Text, nullable=True)
     parsed = Column(Boolean, nullable=True)
-    content = Column(Text, nullable=True)
+    content = Column(String(70000), nullable=True)
 
 
 class Entity:

--- a/API/gimvicurnik/database/__init__.py
+++ b/API/gimvicurnik/database/__init__.py
@@ -167,6 +167,9 @@ class Classroom(Entity, Base):
         days = (1, 5)
         times = Session.query(func.min(Lesson.time), func.max(Lesson.time))[0]
 
+        if times[0] is None or times[1] is None:
+            return []
+
         classrooms = list(Session.query(Classroom).order_by(Classroom.name))
         lessons = list(Session.query(Lesson).join(Classroom))
 

--- a/API/gimvicurnik/updaters/eclassroom.py
+++ b/API/gimvicurnik/updaters/eclassroom.py
@@ -22,6 +22,7 @@ from ..utils.sentry import with_span
 
 if typing.TYPE_CHECKING:
     from typing import Any, Dict, Iterator, List, Optional
+    from mammoth.documents import Image  # type: ignore
     from sqlalchemy.orm import Session
     from sentry_sdk.tracing import Span
     from ..config import ConfigSourcesEClassroom
@@ -213,7 +214,10 @@ class EClassroomUpdater(BaseMultiUpdater):
     def get_content(self, document: DocumentInfo, content: bytes) -> Optional[str]:
         """Get file content of docx circulars."""
 
-        result = convert_to_html(io.BytesIO(content))
+        def ignore_images(_image: Image) -> Dict:
+            return {}
+
+        result = convert_to_html(io.BytesIO(content), convert_image=ignore_images)
         return typing.cast(str, result.value)  # The generated HTML
 
     @with_span(op="parse", pass_span=True)


### PR DESCRIPTION
* Prevent crash on empty classrooms route when timetable is empty.
*  Use mediumtext for document content.
* Do not inline images when parsing content.
