### PR TITLE
Fix menu date parser

### DIFF
--- a/API/gimvicurnik/updaters/menu.py
+++ b/API/gimvicurnik/updaters/menu.py
@@ -149,9 +149,7 @@ class MenuUpdater(BaseMultiUpdater):
 
             # Get start of nth week of the month
             first = datetime.date(year, month, 1)
-            diff = -first.weekday() if month == 9 else 7 - first.weekday()
-            diff = diff if diff < 7 else 0
-            new = first + datetime.timedelta(weeks=week - 1, days=diff)
+            new = first + datetime.timedelta(weeks=week - 1, days=-first.weekday())
 
             return new
 


### PR DESCRIPTION
Menu date format has changed for the first time in (at least) 2 years... Now, the 1st week of the month is the week that includes the 1st day in the month.