### PR TITLE
Mark the course as viewed when updating from the e-classroom

### DIFF
--- a/API/gimvicurnik/updaters/eclassroom.py
+++ b/API/gimvicurnik/updaters/eclassroom.py
@@ -52,8 +52,28 @@ class EClassroomUpdater(BaseMultiUpdater):
     def get_documents(self) -> Iterator[DocumentInfo]:
         """Get all documents from the e-classroom."""
 
+        self._mark_course_viewed()
+
         yield from self._get_internal_urls()
         yield from self._get_external_urls()
+
+    def _mark_course_viewed(self) -> None:
+        """Mark the course as viewed, so we are not removed for inactivity."""
+
+        params = {
+            "moodlewsrestformat": "json",
+        }
+        data = {
+            "courseid": self.config.course,
+            "wstoken": self.config.token,
+            "wsfunction": "core_course_view_course",
+        }
+
+        try:
+            response = requests.post(self.config.webserviceUrl, params=params, data=data)
+            response.raise_for_status()
+        except (IOError, ValueError) as error:
+            raise ClassroomApiError("Error while accessing e-classroom API") from error
 
     def _get_internal_urls(self) -> Iterator[DocumentInfo]:
         params = {


### PR DESCRIPTION
This PR adds an additional call to the Moodle API to mark the course as viewed. This is needed, so we are not removed from the course for inactivity.