### PR TITLE
Refactor updaters to improve code organization

### DIFF
--- a/API/gimvicurnik/updaters/base.py
+++ b/API/gimvicurnik/updaters/base.py
@@ -166,11 +166,7 @@ class BaseMultiUpdater(ABC):
         # == DOCUMENT RECORD (GET)
 
         # Try to find an existing document record
-        record: Document | None = (
-            self.session.query(Document)
-            .filter(Document.type == document.type, Document.url == document.url)
-            .first()
-        )
+        record = self.retrieve_document(document)
 
         # == DOCUMENT PROCESSING
 
@@ -306,6 +302,15 @@ class BaseMultiUpdater(ABC):
             case ("skipped", _):
                 self.logger.info("Skipped because the %s document for %s is already stored", document.type.value, effective)
         # fmt: on
+
+    def retrieve_document(self, document: DocumentInfo) -> Document | None:
+        """Get a document record from the database. May be set by subclasses."""
+
+        return (
+            self.session.query(Document)
+            .filter(Document.type == document.type, Document.url == document.url)
+            .first()
+        )
 
     @with_span(op="download")
     def download_document(self, document: DocumentInfo) -> tuple[BytesIO, str]:

--- a/API/gimvicurnik/utils/pdf.py
+++ b/API/gimvicurnik/utils/pdf.py
@@ -6,6 +6,7 @@ import pdfplumber
 
 if typing.TYPE_CHECKING:
     from typing import Any
+    from io import BytesIO
 
     Tables = list[list[list[str | None]]]
 
@@ -17,12 +18,12 @@ def keep_visible_lines(obj: dict[str, Any]) -> bool:
     return True
 
 
-def extract_tables(filename: str) -> Tables:
+def extract_tables(stream: BytesIO) -> Tables:
     """Extract tables from a PDF file using pdfplumber."""
 
     tables = []
 
-    with pdfplumber.open(filename) as file:
+    with pdfplumber.open(stream) as file:
         for page in file.pages:
             page = page.filter(keep_visible_lines)
             tables.extend(page.extract_tables())


### PR DESCRIPTION
Refactored updaters to improve code organization and readability, and reduce duplicated code. Updaters now also support both parsing and extracting content for the same document. Using temporary file has also been removed in favor of using `BytesIO` streams to fix some edge cases and potentially improve performance. Additionally, more Sentry tags have been added to the updater spans.

Finding document record has been moved into a separate method `retrieve_document`. This makes it possible for specific updaters to provide their own query logic. This may be useful in the future if we add better handling for detecting same documents with different URLs.

Checking checking if document has changed into a separate method `document_has_changed`. This makes it possible for specific updaters to provide their own login for determining if the document has changed, without downloading the document and checking the hash. This can be useful if there is an easy way to determine if the document has changed, for example by comparing modified dates from the source, or other source-specific logic, so we can skip downloading the document. Even if this method returns that the document has changed, we still download the document and compare hashes.