### PR TITLE
Implement various improvements and fixes

### DIFF
--- a/API/gimvicurnik/blueprints/menus.py
+++ b/API/gimvicurnik/blueprints/menus.py
@@ -4,10 +4,10 @@ import typing
 
 from .base import BaseHandler
 from ..database import LunchMenu, Session, SnackMenu
+from ..utils.dates import get_weekdays
 
 if typing.TYPE_CHECKING:
     import datetime
-    from typing import Any
     from flask import Blueprint
     from ..config import Config
 
@@ -17,29 +17,47 @@ class MenusHandler(BaseHandler):
 
     @classmethod
     def routes(cls, bp: Blueprint, config: Config) -> None:
+        def _serialize_snack_menu(snack: SnackMenu) -> dict[str, str | None]:
+            return {
+                "normal": snack.normal,
+                "poultry": snack.poultry,
+                "vegetarian": snack.vegetarian,
+                "fruitvegetable": snack.fruitvegetable,
+            }
+
+        def _serialize_lunch_menu(lunch: LunchMenu) -> dict[str, str | None]:
+            return {
+                "until": lunch.until.isoformat("minutes") if lunch.until else None,
+                "normal": lunch.normal,
+                "vegetarian": lunch.vegetarian,
+            }
+
         @bp.route("/menus/date/<date:date>")
-        def get_menus(date: datetime.date) -> dict[str, dict[str, str] | None]:
-            # We need type "any" here, otherwise mypy complains
-            # See: https://github.com/python/mypy/issues/15101
-            snack: Any = Session.query(SnackMenu).filter(SnackMenu.date == date).first()
-            lunch: Any = Session.query(LunchMenu).filter(LunchMenu.date == date).first()
-
-            if snack:
-                snack = {
-                    "normal": snack.normal,
-                    "poultry": snack.poultry,
-                    "vegetarian": snack.vegetarian,
-                    "fruitvegetable": snack.fruitvegetable,
-                }
-
-            if lunch:
-                lunch = {
-                    "until": lunch.until.strftime("%H:%M") if lunch.until else None,
-                    "normal": lunch.normal,
-                    "vegetarian": lunch.vegetarian,
-                }
+        def get_date_menus(date: datetime.date) -> dict[str, str | dict[str, str | None] | None]:
+            snack = Session.query(SnackMenu).filter(SnackMenu.date == date).first()
+            lunch = Session.query(LunchMenu).filter(LunchMenu.date == date).first()
 
             return {
-                "snack": snack,
-                "lunch": lunch,
+                "date": date.isoformat(),
+                "snack": _serialize_snack_menu(snack) if snack else None,
+                "lunch": _serialize_lunch_menu(lunch) if lunch else None,
             }
+
+        @bp.route("/menus/week/<date:date>")
+        def get_week_menus(date: datetime.date) -> list[dict[str, str | dict[str, str | None] | None]]:
+            weekdays = get_weekdays(date)
+
+            snacks = Session.query(SnackMenu).filter(SnackMenu.date.in_(weekdays)).all()
+            lunches = Session.query(LunchMenu).filter(LunchMenu.date.in_(weekdays)).all()
+
+            snacks = {snack.date: _serialize_snack_menu(snack) for snack in snacks}
+            lunches = {lunch.date: _serialize_lunch_menu(lunch) for lunch in lunches}
+
+            return [
+                {
+                    "date": date.isoformat(),
+                    "snack": snacks.get(date),
+                    "lunch": lunches.get(date),
+                }
+                for date in weekdays
+            ]

--- a/API/gimvicurnik/blueprints/menus.py
+++ b/API/gimvicurnik/blueprints/menus.py
@@ -34,6 +34,7 @@ class MenusHandler(BaseHandler):
 
             if lunch:
                 lunch = {
+                    "until": lunch.until.strftime("%H:%M") if lunch.until else None,
                     "normal": lunch.normal,
                     "vegetarian": lunch.vegetarian,
                 }

--- a/API/gimvicurnik/blueprints/schedule.py
+++ b/API/gimvicurnik/blueprints/schedule.py
@@ -4,6 +4,7 @@ import typing
 
 from .base import BaseHandler
 from ..database import Class, LunchSchedule, Session
+from ..utils.dates import get_weekdays
 
 if typing.TYPE_CHECKING:
     import datetime
@@ -17,38 +18,75 @@ class ScheduleHandler(BaseHandler):
 
     @classmethod
     def routes(cls, bp: Blueprint, config: Config) -> None:
+        def _serialize_schedule(schedule: LunchSchedule, class_: str) -> dict[str, Any]:
+            return {
+                "class": class_,
+                "date": schedule.date.isoformat(),
+                "time": schedule.time.isoformat("minutes") if schedule.time else None,
+                "location": schedule.location,
+                "notes": schedule.notes,
+            }
+
+        def _fetch_schedules_for_date(
+            date: datetime.date,
+            classes: list[str] | None = None,
+        ) -> list[dict[str, Any]]:
+            """Fetch lunch schedules for a specific date."""
+
+            query = (
+                Session.query(LunchSchedule, Class.name)
+                .join(Class)
+                .filter(LunchSchedule.date == date)
+                .order_by(LunchSchedule.time, LunchSchedule.class_)
+            )
+
+            if classes:
+                query = query.filter(Class.name.in_(classes))
+
+            return [_serialize_schedule(model[0], model[1]) for model in query]
+
+        def _fetch_schedules_for_week(
+            weekdays: list[datetime.date],
+            classes: list[str] | None = None,
+        ) -> dict[datetime.date, list[dict[str, Any]]]:
+            """Fetch lunch schedules for a specific week."""
+
+            query = (
+                Session.query(LunchSchedule, Class.name)
+                .join(Class)
+                .filter(LunchSchedule.date.in_(weekdays))
+                .order_by(LunchSchedule.time, LunchSchedule.class_)
+            )
+
+            if classes:
+                query = query.filter(Class.name.in_(classes))
+
+            schedules: dict[datetime.date, list[dict[str, Any]]] = {day: [] for day in weekdays}
+
+            for schedule, class_ in query.all():
+                schedules[schedule.date].append(_serialize_schedule(schedule, class_))
+
+            return schedules
+
         @bp.route("/schedule/date/<date:date>")
-        def get_lunch_schedule(date: datetime.date) -> list[dict[str, Any]]:
-            return [
-                {
-                    "class": model[1],
-                    "date": model[0].date.strftime("%Y-%m-%d"),
-                    "time": model[0].time.strftime("%H:%M") if model[0].time else None,
-                    "location": model[0].location,
-                    "notes": model[0].notes,
-                }
-                for model in (
-                    Session.query(LunchSchedule, Class.name)
-                    .join(Class)
-                    .filter(LunchSchedule.date == date)
-                    .order_by(LunchSchedule.time, LunchSchedule.class_)
-                )
-            ]
+        def get_date_schedule(date: datetime.date) -> list[dict[str, Any]]:
+            return _fetch_schedules_for_date(date)
 
         @bp.route("/schedule/date/<date:date>/classes/<list:classes>")
-        def get_lunch_schedule_for_classes(date: datetime.date, classes: list[str]) -> list[dict[str, Any]]:
-            return [
-                {
-                    "class": model[1],
-                    "date": model[0].date.strftime("%Y-%m-%d"),
-                    "time": model[0].time.strftime("%H:%M") if model[0].time else None,
-                    "location": model[0].location,
-                    "notes": model[0].notes,
-                }
-                for model in (
-                    Session.query(LunchSchedule, Class.name)
-                    .join(Class)
-                    .filter(LunchSchedule.date == date, Class.name.in_(classes))
-                    .order_by(LunchSchedule.time, LunchSchedule.class_)
-                )
-            ]
+        def get_date_schedule_for_classes(date: datetime.date, classes: list[str]) -> list[dict[str, Any]]:
+            return _fetch_schedules_for_date(date, classes)
+
+        @bp.route("/schedule/week/<date:date>")
+        def get_week_schedule(date: datetime.date) -> list[list[dict[str, Any]]]:
+            weekdays = get_weekdays(date)
+            schedules = _fetch_schedules_for_week(weekdays)
+            return list(schedules.values())
+
+        @bp.route("/schedule/week/<date:date>/classes/<list:classes>")
+        def get_week_schedule_for_classes(
+            date: datetime.date,
+            classes: list[str],
+        ) -> list[list[dict[str, Any]]]:
+            weekdays = get_weekdays(date)
+            schedules = _fetch_schedules_for_week(weekdays, classes)
+            return list(schedules.values())

--- a/API/gimvicurnik/blueprints/substitutions.py
+++ b/API/gimvicurnik/blueprints/substitutions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing
 
+from ..utils.dates import get_weekdays
 from .base import BaseHandler
 from ..database import Class, Classroom, Entity, Teacher
 
@@ -17,27 +18,69 @@ class SubstitutionsHandler(BaseHandler):
 
     @classmethod
     def routes(cls, bp: Blueprint, config: Config) -> None:
+        def _fetch_week_substitutions(
+            date: datetime.date,
+            entity: type[Entity],
+            names: list[str],
+        ) -> list[list[dict[str, Any]]]:
+            """Fetch substitutions for a week containing the given date."""
+
+            weekdays = get_weekdays(date)
+            substitutions = entity.get_substitutions(weekdays, names)
+
+            grouped: dict[str, list[dict[str, Any]]] = {day.isoformat(): [] for day in weekdays}
+
+            for substitution in substitutions:
+                grouped[substitution["date"]].append(substitution)
+
+            return list(grouped.values())
+
         @bp.route("/substitutions/date/<date:date>")
-        def get_substitutions(date: datetime.date) -> list[dict[str, Any]]:
-            return list(Entity.get_substitutions(date))
+        def get_date_substitutions(date: datetime.date) -> list[dict[str, Any]]:
+            return list(Entity.get_substitutions([date]))
 
         @bp.route("/substitutions/date/<date:date>/classes/<list:classes>")
-        def get_substitutions_for_classes(
+        def get_date_substitutions_for_classes(
             date: datetime.date,
             classes: list[str],
         ) -> list[dict[str, Any]]:
-            return list(Class.get_substitutions(date, classes))
+            return list(Class.get_substitutions([date], classes))
 
         @bp.route("/substitutions/date/<date:date>/teachers/<list:teachers>")
-        def get_substitutions_for_teachers(
+        def get_date_substitutions_for_teachers(
             date: datetime.date,
             teachers: list[str],
         ) -> list[dict[str, Any]]:
-            return list(Teacher.get_substitutions(date, teachers))
+            return list(Teacher.get_substitutions([date], teachers))
 
         @bp.route("/substitutions/date/<date:date>/classrooms/<list:classrooms>")
-        def get_substitutions_for_classrooms(
+        def get_date_substitutions_for_classrooms(
             date: datetime.date,
             classrooms: list[str],
         ) -> list[dict[str, Any]]:
-            return list(Classroom.get_substitutions(date, classrooms))
+            return list(Classroom.get_substitutions([date], classrooms))
+
+        @bp.route("/substitutions/week/<date:date>")
+        def get_week_substitutions(date: datetime.date) -> list[list[dict[str, Any]]]:
+            return _fetch_week_substitutions(date, Entity, [])
+
+        @bp.route("/substitutions/week/<date:date>/classes/<list:classes>")
+        def get_week_substitutions_for_classes(
+            date: datetime.date,
+            classes: list[str],
+        ) -> list[list[dict[str, Any]]]:
+            return _fetch_week_substitutions(date, Class, classes)
+
+        @bp.route("/substitutions/week/<date:date>/teachers/<list:teachers>")
+        def get_week_substitutions_for_teachers(
+            date: datetime.date,
+            teachers: list[str],
+        ) -> list[list[dict[str, Any]]]:
+            return _fetch_week_substitutions(date, Teacher, teachers)
+
+        @bp.route("/substitutions/week/<date:date>/classrooms/<list:classrooms>")
+        def get_week_substitutions_for_classrooms(
+            date: datetime.date,
+            classrooms: list[str],
+        ) -> list[list[dict[str, Any]]]:
+            return _fetch_week_substitutions(date, Classroom, classrooms)

--- a/API/gimvicurnik/database/__init__.py
+++ b/API/gimvicurnik/database/__init__.py
@@ -122,7 +122,7 @@ class Entity:
     @classmethod
     def get_substitutions(
         cls,
-        date: date_ | None = None,
+        dates: list[date_] | None = None,
         names: list[str] | None = None,
     ) -> Iterator[dict[str, Any]]:
         original_teacher = aliased(Teacher)
@@ -143,8 +143,8 @@ class Entity:
         )
         # fmt: on
 
-        if date:
-            query = query.filter(Substitution.date == date)
+        if dates:
+            query = query.filter(Substitution.date.in_(dates))
 
         if names:
             if cls.__tablename__ == "classes":

--- a/API/gimvicurnik/database/__init__.py
+++ b/API/gimvicurnik/database/__init__.py
@@ -156,7 +156,7 @@ class Entity:
 
         for model in query:
             yield {
-                "date": model[0].date.strftime("%Y-%m-%d"),
+                "date": model[0].date.isoformat(),
                 "day": model[0].day,
                 "time": model[0].time,
                 "subject": model[0].subject,

--- a/API/gimvicurnik/database/__init__.py
+++ b/API/gimvicurnik/database/__init__.py
@@ -287,5 +287,7 @@ class LunchMenu(Base):
     id: Mapped[intpk]
     date: Mapped[date_] = mapped_column(unique=True, index=True)
 
+    until: Mapped[time_ | None]
+
     normal: Mapped[text | None]
     vegetarian: Mapped[text | None]

--- a/API/gimvicurnik/updaters/eclassroom.py
+++ b/API/gimvicurnik/updaters/eclassroom.py
@@ -251,7 +251,7 @@ class EClassroomUpdater(BaseMultiUpdater):
         return document.title
 
     @typing.no_type_check  # Ignored because if regex fails, we cannot do anything
-    def get_document_effective(self, document: DocumentInfo) -> date:
+    def get_document_effective(self, document: DocumentInfo) -> date | None:
         """Return the document effective date in a local timezone."""
 
         if document.type == DocumentType.SUBSTITUTIONS:
@@ -262,9 +262,6 @@ class EClassroomUpdater(BaseMultiUpdater):
             title = document.title.split(",")[-1].split("-")[-1].strip()
             search = re.search(r"(\d+) *\. *(\d+) *\. *(\d+)", title)
             return date(year=int(search.group(3)), month=int(search.group(2)), day=int(search.group(1)))
-
-        # This cannot happen because only substitutions and schedules are provided
-        raise KeyError("Unknown parsable document type from the e-classroom")
 
     def document_needs_parsing(self, document: DocumentInfo) -> bool:
         """Return whether the document needs parsing."""
@@ -305,7 +302,7 @@ class EClassroomUpdater(BaseMultiUpdater):
                     "Unknown lunch schedule document format: " + str(document.extension)
                 )
             case _:
-                # This cannot happen because only menus are provided by the API
+                # This cannot happen because only these types are provided by the API
                 raise KeyError("Unknown parsable document type from the e-classroom")
 
     def document_needs_extraction(self, document: DocumentInfo) -> bool:

--- a/API/gimvicurnik/updaters/solsis.py
+++ b/API/gimvicurnik/updaters/solsis.py
@@ -23,6 +23,7 @@ from ..utils.sentry import sentry_available, with_span
 
 if typing.TYPE_CHECKING:
     from sqlalchemy.orm import Session
+    from sentry_sdk.tracing import Span
     from ..config import ConfigSourcesSolsis
 
 
@@ -116,6 +117,7 @@ class SolsisUpdater:
         date_to: date_,
     ) -> None:
         self.logger = logging.getLogger(__name__)
+        self.requests = requests.Session()
         self.config = config
         self.session = session
 
@@ -125,99 +127,145 @@ class SolsisUpdater:
     def update(self) -> None:
         """Update Solsis files."""
 
-        try:
-            self.get_substitutions()
+        self.update_substitutions()
 
-        except Exception as error:
-            if sentry_available:
-                import sentry_sdk
+    def update_substitutions(self) -> None:
+        """Update the substitutions from Solsis."""
 
-                # fmt: off
-                sentry_sdk.set_context("document", {
-                    "URL": self.config.url,
-                    "source": self.source,
-                    "type​": DocumentType.SUBSTITUTIONS.value
-                })
-                # fmt: on
-
-                sentry_sdk.set_tag("document_source", self.source)
-                sentry_sdk.set_tag("document_type", DocumentType.SUBSTITUTIONS.value)
-
-            self.logger.exception(error)
-
-    def get_substitutions(self) -> None:
         # Generate span of dates
         dates = [self.date_from + timedelta(days=i) for i in range((self.date_to - self.date_from).days + 1)]
 
         for date in dates:
-            self.logger.info("Handling substitutions for %s", date, extra={"date": date})
-
-            # Download and parse the Solsis JSON
-            solsis_substitutions: TypeRoot = self._download_substitutions(date)
-
-            # Skip empty substitutions as the API returns only the date
-            if "nadomescanja" not in solsis_substitutions:
-                continue
-
-            day = date.isoweekday()
-            substitutions = []
-
-            # Loop through the Solsis substitutions sections and construct models for a database
-
-            # Substitutions (Teacher is absent)
-            for substitution in solsis_substitutions["nadomescanja"]:
-                # Get the original teacher
-                original_teacher = normalize_teacher_name(substitution["odsoten_fullname"])
-
-                for lesson in substitution["nadomescanja_ure"]:
-                    # Get basic substitution properties
-                    time = int(lesson["ura"][:-1]) if lesson["ura"] != "PU" else 0
-                    subject = normalize_subject_name(lesson["predmet"])
-                    notes = normalize_other_names(lesson["opomba"])
-
-                    # Get the new teacher
-                    teacher = normalize_teacher_name(lesson["nadomesca_full_name"])
-
-                    # Get the classroom (which stays the same)
-                    # There may be multiple classrooms per entry
-                    classrooms = [normalize_classroom_name(name) for name in lesson["ucilnica"].split(", ")]
-
-                    # Handle multiple classes
-                    classes = lesson["class_name"].upper().replace(". ", "").split(" - ")
-                    classes = classes[:-1] if len(classes) > 1 else classes
+            try:
+                # Update the substitutions for each date
+                self.update_substitutions_for_date(date)  # type: ignore[call-arg]
+            except Exception as error:
+                if sentry_available:
+                    import sentry_sdk
 
                     # fmt: off
-                    for class_, classroom in product(classes, classrooms):
-                        substitutions.append(format_substitution(
+                    sentry_sdk.set_context("document", {
+                        "URL": self.config.url,
+                        "source": self.source,
+                        "type​": DocumentType.SUBSTITUTIONS.value,
+                        "format": "json",
+                        "effective": date.isoformat()
+                    })
+                    # fmt: on
+
+                    sentry_sdk.set_tag("document_source", self.source)
+                    sentry_sdk.set_tag("document_type", DocumentType.SUBSTITUTIONS.value)
+                    sentry_sdk.set_tag("document_format", "json")
+
+                self.logger.exception(error)
+
+    @with_span(op="substitutions", pass_span=True)
+    def update_substitutions_for_date(self, date: date_, span: Span) -> None:
+        """Update the substitutions for a specific date."""
+
+        self.logger.info("Handling substitutions for %s", date, extra={"date": date})
+
+        span.description = date.isoformat()
+        span.set_tag("document.url", self.config.url)
+        span.set_tag("document.source", self.source)
+        span.set_tag("document.type", DocumentType.SUBSTITUTIONS.value)
+        span.set_tag("document.format", "json")
+        span.set_tag("document.effective", date.isoformat())
+
+        # Download and parse the Solsis JSON
+        response: TypeRoot = self.download_substitutions_for_date(date)
+
+        # Skip empty substitutions as the API returns only the date
+        if "nadomescanja" not in response:
+            return
+
+        # Parse the Solsis JSON and store substitutions to the database
+        self.parse_substitutions_for_date(response, date)
+
+    @with_span(op="download")
+    def download_substitutions_for_date(self, date: date_) -> TypeRoot:
+        """Download and parse the Solsis JSON file."""
+
+        # Every request needs a different nonsense
+        nonsense = f"{getrandbits(128):032x}"
+
+        # Compose the URL
+        params = f"func=gateway&call=suplence&datum={date.isoformat()}&nonsense={nonsense}"
+        signature_string = f"{self.config.serverName}||{params}||{self.config.apiKey}"
+        signature_hash = sha256(signature_string.encode()).hexdigest()
+        url = f"{self.config.url}?{params}&signature={signature_hash}"
+
+        try:
+            response = self.requests.get(url)
+            response.raise_for_status()
+            return typing.cast(TypeRoot, response.json())
+
+        except (OSError, ValueError) as error:
+            raise SolsisApiError("Error while downloading substitutions from Solsis API") from error
+
+    @with_span(op="parse")
+    def parse_substitutions_for_date(self, response: TypeRoot, date: date_) -> None:
+        """Parse the Solsis JSON file and store substitutions."""
+
+        day = date.isoweekday()
+        substitutions = []
+
+        # Loop through the Solsis substitutions sections and construct models for a database
+
+        # Substitutions (Teacher is absent)
+        for substitution in response["nadomescanja"]:
+            # Get the original teacher
+            original_teacher = normalize_teacher_name(substitution["odsoten_fullname"])
+
+            for lesson in substitution["nadomescanja_ure"]:
+                # Get basic substitution properties
+                time = int(lesson["ura"][:-1]) if lesson["ura"] != "PU" else 0
+                subject = normalize_subject_name(lesson["predmet"])
+                notes = normalize_other_names(lesson["opomba"])
+
+                # Get the new teacher
+                teacher = normalize_teacher_name(lesson["nadomesca_full_name"])
+
+                # Get the classroom (which stays the same)
+                # There may be multiple classrooms per entry
+                classrooms = [normalize_classroom_name(name) for name in lesson["ucilnica"].split(", ")]
+
+                # Handle multiple classes
+                classes = lesson["class_name"].upper().replace(". ", "").split(" - ")
+                classes = classes[:-1] if len(classes) > 1 else classes
+
+                # fmt: off
+                for class_, classroom in product(classes, classrooms):
+                    substitutions.append(format_substitution(
                             self.session,
                             date, day, time,
                             subject, notes,
                             original_teacher, classroom,
                             class_, teacher, classroom,
                         ))
-                    # fmt: on
+                # fmt: on
 
-            # Subject change
-            for substitution in solsis_substitutions["menjava_predmeta"]:
-                # Get basic substitution properties
-                time = int(substitution["ura"][:-1]) if substitution["ura"] != "PU" else 0
-                subject = normalize_subject_name(substitution["predmet"])
-                notes = normalize_other_names(substitution["opomba"])
+        # Subject change
+        for substitution in response["menjava_predmeta"]:
+            # Get basic substitution properties
+            time = int(substitution["ura"][:-1]) if substitution["ura"] != "PU" else 0
+            subject = normalize_subject_name(substitution["predmet"])
+            notes = normalize_other_names(substitution["opomba"])
 
-                # Get the teacher (which stays the same)
-                teacher = normalize_teacher_name(substitution["ucitelj"])
+            # Get the teacher (which stays the same)
+            teacher = normalize_teacher_name(substitution["ucitelj"])
 
-                # Get the classroom (which stays the same)
-                # There may be multiple classrooms per entry
-                classrooms = [normalize_classroom_name(name) for name in substitution["ucilnica"].split(", ")]
+            # Get the classroom (which stays the same)
+            # There may be multiple classrooms per entry
+            classrooms = [normalize_classroom_name(name) for name in substitution["ucilnica"].split(", ")]
 
-                # Handle multiple classes
-                classes = substitution["class_name"].upper().replace(". ", "").split(" - ")
-                classes = classes[:-1] if len(classes) > 1 else classes
+            # Handle multiple classes
+            classes = substitution["class_name"].upper().replace(". ", "").split(" - ")
+            classes = classes[:-1] if len(classes) > 1 else classes
 
-                # fmt: off
-                for class_, classroom in product(classes, classrooms):
-                    substitutions.append(
+            # fmt: off
+            for class_, classroom in product(classes, classrooms):
+                substitutions.append(
                         format_substitution(
                             self.session,
                             date, day, time,
@@ -226,41 +274,41 @@ class SolsisUpdater:
                             class_, teacher, classroom,
                         )
                     )
-                # fmt: on
+            # fmt: on
 
-            # Lesson change
-            for substitution in solsis_substitutions["menjava_ur"]:
-                # Get basic substitution properties
-                time = int(substitution["ura"][:-1]) if substitution["ura"] != "PU" else 0
-                subject = normalize_subject_name(substitution["predmet"].split(" -> ")[1])
-                notes = normalize_other_names(substitution["opomba"])
+        # Lesson change
+        for substitution in response["menjava_ur"]:
+            # Get basic substitution properties
+            time = int(substitution["ura"][:-1]) if substitution["ura"] != "PU" else 0
+            subject = normalize_subject_name(substitution["predmet"].split(" -> ")[1])
+            notes = normalize_other_names(substitution["opomba"])
 
-                # Get the original and the new teacher
-                split_teachers = substitution["zamenjava_uciteljev"].split(" -> ")
-                original_teacher = normalize_teacher_name(split_teachers[0])
-                teacher = normalize_teacher_name(split_teachers[1])
+            # Get the original and the new teacher
+            split_teachers = substitution["zamenjava_uciteljev"].split(" -> ")
+            original_teacher = normalize_teacher_name(split_teachers[0])
+            teacher = normalize_teacher_name(split_teachers[1])
 
-                # Handle classrooms change
-                split_classrooms = substitution["ucilnica"].split(" -> ")
+            # Handle classrooms change
+            split_classrooms = substitution["ucilnica"].split(" -> ")
 
-                # Get the original classrooms
-                # fmt: off
-                original_classrooms = [normalize_classroom_name(name) for name in split_classrooms[0].split(", ")]
-                # fmt: on
+            # Get the original classrooms
+            # fmt: off
+            original_classrooms = [normalize_classroom_name(name) for name in split_classrooms[0].split(", ")]
+            # fmt: on
 
-                # Check if the classrooms have changed
-                if len(split_classrooms) == 2:
-                    classrooms = [normalize_classroom_name(name) for name in split_classrooms[1].split(", ")]
-                else:
-                    classrooms = original_classrooms
+            # Check if the classrooms have changed
+            if len(split_classrooms) == 2:
+                classrooms = [normalize_classroom_name(name) for name in split_classrooms[1].split(", ")]
+            else:
+                classrooms = original_classrooms
 
-                # Handle multiple classes
-                classes = substitution["class_name"].upper().replace(". ", "").split(" - ")
-                classes = classes[:-1] if len(classes) > 1 else classes
+            # Handle multiple classes
+            classes = substitution["class_name"].upper().replace(". ", "").split(" - ")
+            classes = classes[:-1] if len(classes) > 1 else classes
 
-                # fmt: off
-                for class_, original_classroom, classroom in product(classes, original_classrooms, classrooms):
-                    substitutions.append(
+            # fmt: off
+            for class_, original_classroom, classroom in product(classes, original_classrooms, classrooms):
+                substitutions.append(
                         format_substitution(
                             self.session,
                             date, day, time,
@@ -269,34 +317,34 @@ class SolsisUpdater:
                             class_, teacher, classroom,
                         )
                     )
-                # fmt: on
+            # fmt: on
 
-            # Classroom change
-            for substitution in solsis_substitutions["menjava_ucilnic"]:
-                # Get basic substitution properties
-                time = int(substitution["ura"][:-1]) if substitution["ura"] != "PU" else 0
-                subject = normalize_subject_name(substitution["predmet"])
-                notes = normalize_other_names(substitution["opomba"])
+        # Classroom change
+        for substitution in response["menjava_ucilnic"]:
+            # Get basic substitution properties
+            time = int(substitution["ura"][:-1]) if substitution["ura"] != "PU" else 0
+            subject = normalize_subject_name(substitution["predmet"])
+            notes = normalize_other_names(substitution["opomba"])
 
-                # Get the teacher (which stays the same)
-                teacher = normalize_teacher_name(substitution["ucitelj"])
+            # Get the teacher (which stays the same)
+            teacher = normalize_teacher_name(substitution["ucitelj"])
 
-                # Get the original and the new classrooms
-                # fmt: off
-                original_classrooms = [normalize_classroom_name(name) for name in substitution["ucilnica_from"].split(", ")]
-                classrooms = [normalize_classroom_name(name) for name in substitution["ucilnica_to"].split(", ")]
-                # fmt: off
+            # Get the original and the new classrooms
+            # fmt: off
+            original_classrooms = [normalize_classroom_name(name) for name in substitution["ucilnica_from"].split(", ")]
+            classrooms = [normalize_classroom_name(name) for name in substitution["ucilnica_to"].split(", ")]
+            # fmt: off
 
-                # Handle multiple classes
-                classes = substitution["class_name"].upper().replace(". ", "").split(" - ")
-                classes = classes[:-1] if len(classes) > 1 else classes
+            # Handle multiple classes
+            classes = substitution["class_name"].upper().replace(". ", "").split(" - ")
+            classes = classes[:-1] if len(classes) > 1 else classes
 
-                # fmt: off
-                for class_, original_classroom, classroom in product(classes, original_classrooms, classrooms):
-                    if original_classroom == classroom:
-                        continue
+            # fmt: off
+            for class_, original_classroom, classroom in product(classes, original_classrooms, classrooms):
+                if original_classroom == classroom:
+                    continue
 
-                    substitutions.append(
+                substitutions.append(
                         format_substitution(
                             self.session,
                             date, day, time,
@@ -305,35 +353,14 @@ class SolsisUpdater:
                             class_, teacher, classroom,
                         )
                     )
-                # fmt: on
+            # fmt: on
 
-            # Deduplicate substitutions
-            substitutions = list({frozenset(subs.items()): subs for subs in substitutions}.values())
+        # Deduplicate substitutions
+        substitutions = list({frozenset(subs.items()): subs for subs in substitutions}.values())
 
-            # Remove old substitutions from the database
-            self.session.query(Substitution).filter(Substitution.date == date).delete()
+        # Remove old substitutions from the database
+        self.session.query(Substitution).filter(Substitution.date == date).delete()
 
-            # Store new substitutions to the database
-            if substitutions:
-                self.session.execute(insert(Substitution), substitutions)
-
-    @with_span(op="download")
-    def _download_substitutions(self, date: date_) -> TypeRoot:
-        """Download and parse the Solsis JSON file."""
-
-        # Every request needs a different nonsense
-        nonsense = f"{getrandbits(128):032x}"
-
-        # Compose the URL
-        params = f"func=gateway&call=suplence&datum={date.strftime('%Y-%m-%d')}&nonsense={nonsense}"
-        signature_string = f"{self.config.serverName}||{params}||{self.config.apiKey}"
-        signature = sha256(signature_string.encode()).hexdigest()
-        url = f"{self.config.url}?{params}&signature={signature}"
-
-        try:
-            response = requests.get(url)
-            response.raise_for_status()
-            return typing.cast(TypeRoot, response.json())
-
-        except (OSError, ValueError) as error:
-            raise SolsisApiError("Error while downloading substitutions from Solsis API") from error
+        # Store new substitutions to the database
+        if substitutions:
+            self.session.execute(insert(Substitution), substitutions)

--- a/API/gimvicurnik/updaters/timetable.py
+++ b/API/gimvicurnik/updaters/timetable.py
@@ -22,6 +22,8 @@ if typing.TYPE_CHECKING:
 
 
 class TimetableUpdater:
+    source = "timetable"
+
     def __init__(self, config: ConfigSourcesTimetable, session: Session) -> None:
         self.logger = logging.getLogger(__name__)
         self.config = config
@@ -40,13 +42,15 @@ class TimetableUpdater:
                 # fmt: off
                 sentry_sdk.set_context("document", {
                     "URL": self.config.url,
-                    "source": DocumentType.TIMETABLE.value,
-                    "type​": DocumentType.TIMETABLE.value
+                    "source": self.source,
+                    "type​": DocumentType.TIMETABLE.value,
+                    "format": "js"
                 })
                 # fmt: on
 
-                sentry_sdk.set_tag("document_source", DocumentType.TIMETABLE.value)
+                sentry_sdk.set_tag("document_source", self.source)
                 sentry_sdk.set_tag("document_type", DocumentType.TIMETABLE.value)
+                sentry_sdk.set_tag("document_format", "js")
 
             self.logger.exception(error)
 
@@ -56,8 +60,9 @@ class TimetableUpdater:
 
         span.description = self.config.url
         span.set_tag("document.url", self.config.url)
-        span.set_tag("document.source", DocumentType.TIMETABLE.value)
+        span.set_tag("document.source", self.source)
         span.set_tag("document.type", DocumentType.TIMETABLE.value)
+        span.set_tag("document.format", "js")
         span.set_tag("document.action", "crashed")
 
         # Download the timetable JS and get its hash

--- a/API/gimvicurnik/utils/dates.py
+++ b/API/gimvicurnik/utils/dates.py
@@ -1,0 +1,20 @@
+import datetime
+
+
+def get_weekdays(date: datetime.date) -> list[datetime.date]:
+    """
+    Get weekdays of the week containing the specified date.
+
+    The weekdays are returned as a list of dates, where the first element
+    is Monday and the last is Friday.  If the specified date is a weekend,
+    the weekdays of the next week are returned.
+    """
+
+    if date.weekday() >= 5:
+        # If the date is weekend, move to the next Monday
+        date += datetime.timedelta(days=(7 - date.weekday()))
+
+    monday = date - datetime.timedelta(days=date.weekday())
+    weekdays = [monday + datetime.timedelta(days=i) for i in range(5)]
+
+    return weekdays

--- a/API/gimvicurnik/utils/flask.py
+++ b/API/gimvicurnik/utils/flask.py
@@ -23,7 +23,7 @@ class DateConverter(BaseConverter):
             raise ValidationError() from error
 
     def to_url(self, value: date) -> str:
-        return value.strftime("%Y-%m-%d")
+        return value.isoformat()
 
 
 class ListConverter(BaseConverter):

--- a/website/src/components/CommonAbout.vue
+++ b/website/src/components/CommonAbout.vue
@@ -25,9 +25,10 @@ defineProps<{
       <a href="https://github.com/filips123/GimVicUrnik/wiki" target="_blank">dokumentaciji</a>.
     </p>
     <p v-if="showDataCollection">
-      Aplikacija zbira omejene podatke o brskalniku in uporabi za namene odpravljanja napak in
-      izboljšanja učinkovitosti. Podatki se ne uporabljajo za identifikacijo uporabnikov,
-      oglaševanje ali druge namene.
+      Aplikacija s pomočjo storitve
+      <a href="https://sentry.io/privacy/" target="_blank">Sentry</a> zbira omejene podatke o
+      napravi in uporabi za namene odpravljanja napak ter izboljšanja učinkovitosti. Podatki se ne
+      uporabljajo za identifikacijo uporabnikov, oglaševanje ali druge namene.
     </p>
     <span v-if="showDevelopers">Razvijalci:</span>
     <ul v-if="showDevelopers">
@@ -38,7 +39,7 @@ defineProps<{
     <p v-if="showFeedback">
       Če ste odkrili napako v aplikaciji ali podatkih, želite prispevati k razvoju ali ponuditi
       povratne informacije, lahko to naredite na
-      <a href="https://github.com/filips123/GimVicUrnik/issues/new/choose" target="_blank"
+      <a href="https://github.com/filips123/GimVicUrnik/wiki/Povratne-informacije" target="_blank"
         >uradnem repozitoriju</a
       >.
     </p>

--- a/website/src/components/MenuDisplay.vue
+++ b/website/src/components/MenuDisplay.vue
@@ -23,6 +23,9 @@ const lunchMenu = computed(() => props.menu?.lunch?.[lunchType.value])
     :subtitle="localizeDate(menu.date)"
     class="bg-surface-subtle"
   />
+  <v-card-main v-else class="bg-surface-subtle text-center">
+    <v-card-title class="opacity-70">{{ localizeDate(menu.date) }}</v-card-title>
+  </v-card-main>
   <v-card-main v-if="snackMenu" title="Malica" :text="snackMenu" />
   <v-card-main v-if="lunchMenu" title="Kosilo" :text="lunchMenu" />
   <v-card-main v-if="lunchSchedules?.length" title="Razpored kosila">

--- a/website/src/components/SettingsSelectEntity.vue
+++ b/website/src/components/SettingsSelectEntity.vue
@@ -72,8 +72,10 @@ const availableList = computed(() => {
 
 // Display the correct dialogs based on state
 useEventListener(window, 'popstate', event => {
-  entityTypeDialog.value = event.state.entityTypeDialog
-  entityListDialog.value = event.state.entityListDialog
+  if (event.state?.entityTypeDialog && event.state?.entityListDialog) {
+    entityTypeDialog.value = event.state.entityTypeDialog
+    entityListDialog.value = event.state.entityListDialog
+  }
 })
 
 // Replace the history state with the initial state

--- a/website/src/components/TimetableDisplay.vue
+++ b/website/src/components/TimetableDisplay.vue
@@ -147,10 +147,10 @@ function filterForTargetDay(lessonsTime: MergedLesson[][]) {
 /* Add style for current time */
 
 .current-time {
-  background: repeating-linear-gradient(
+  background-image: repeating-linear-gradient(
     -45deg,
-    rgba(255, 0, 0, 0),
-    rgba(255, 0, 0, 0) 20px,
+    transparent,
+    transparent 20px,
     rgba(var(--v-current-time-color), var(--v-current-time-opacity)) 20px,
     rgba(var(--v-current-time-color), var(--v-current-time-opacity)) 40px
   );

--- a/website/src/plugins/vuetify.ts
+++ b/website/src/plugins/vuetify.ts
@@ -37,8 +37,8 @@ const darkTheme: ThemeDefinition = {
   variables: {
     'app-subtitle-opacity': 0.8,
     'card-subtitle-opacity': 0.8,
-    'current-time-color': '#121212',
-    'current-time-opacity': 0.4,
+    'current-time-color': '#000000',
+    'current-time-opacity': 0.31,
     'overlay-color': '#121212',
     'overlay-opacity': 0.48,
   },

--- a/website/src/registerSentry.ts
+++ b/website/src/registerSentry.ts
@@ -19,11 +19,6 @@ import {
   reportingObserverIntegration,
   thirdPartyErrorFilterIntegration,
 } from '@sentry/vue'
-import {
-  usePreferredColorScheme,
-  usePreferredContrast,
-  usePreferredReducedMotion,
-} from '@vueuse/core'
 import type { App } from 'vue'
 import type { Router } from 'vue-router'
 
@@ -34,11 +29,6 @@ export default function registerSentry(app: App, router: Router) {
 
   const { dataCollectionCrashes, dataCollectionPerformance } = useSettingsStore()
   if (!dataCollectionCrashes && !dataCollectionPerformance) return
-
-  // Initialize stores for some interesting media queries
-  const preferredColor = usePreferredColorScheme()
-  const preferredContrast = usePreferredContrast()
-  const preferredMotion = usePreferredReducedMotion()
 
   // Get release prefixes and suffixes from config
   const releasePrefix = import.meta.env.VITE_SENTRY_RELEASE_PREFIX || ''
@@ -160,16 +150,20 @@ export default function registerSentry(app: App, router: Router) {
       'window-controls-overlay',
       'picture-in-picture',
     ]
-    for (const mode of displayModes) {
-      if (window.matchMedia(`(display-mode: ${mode})`).matches) {
-        event.tags['media.display_mode'] = mode
+    for (const displayMode of displayModes) {
+      if (window.matchMedia(`(display-mode: ${displayMode})`).matches) {
+        event.tags['media.display_mode'] = displayMode
         break
       }
     }
 
-    event.tags['media.color_scheme'] = preferredColor.value
-    event.tags['media.contrast'] = preferredContrast.value
-    event.tags['media.reduced_motion'] = preferredMotion.value
+    const colorSchemes = ['light', 'dark']
+    for (const colorScheme of colorSchemes) {
+      if (window.matchMedia(`(prefers-color-scheme: ${colorScheme})`).matches) {
+        event.tags['media.color_scheme'] = colorScheme
+        break
+      }
+    }
 
     // Return the modified event
     return event

--- a/website/src/registerSentry.ts
+++ b/website/src/registerSentry.ts
@@ -66,23 +66,24 @@ export default function registerSentry(app: App, router: Router) {
   }
 
   // Track only base components for performance
-  const trackedComponents = [
-    '<VApp>',
-    '<VAppBar>',
-    '<VMain>',
-    '<RouterView>',
-    '<NavigationDesktop>',
-    '<NavigationMobile>',
-    '<NavigationDay>',
-    '<ViewTimetable>',
-    '<ViewMenu>',
-    '<ViewCirculars>',
-    '<ViewSources>',
-    '<ViewSubscribe>',
-    '<ViewSettings>',
-    '<ViewWelcome>',
-    '<NotFound>',
-  ]
+  // Disabled temporarily until issues are resolved
+  // const trackedComponents = [
+  //   '<VApp>',
+  //   '<VAppBar>',
+  //   '<VMain>',
+  //   '<RouterView>',
+  //   '<NavigationDesktop>',
+  //   '<NavigationMobile>',
+  //   '<NavigationDay>',
+  //   '<ViewTimetable>',
+  //   '<ViewMenu>',
+  //   '<ViewCirculars>',
+  //   '<ViewSources>',
+  //   '<ViewSubscribe>',
+  //   '<ViewSettings>',
+  //   '<ViewWelcome>',
+  //   '<NotFound>',
+  // ]
 
   // Init the Sentry SDK
   sentryInit({
@@ -99,7 +100,7 @@ export default function registerSentry(app: App, router: Router) {
     release: releasePrefix + import.meta.env.VITE_VERSION + releaseSuffix,
 
     autoSessionTracking: dataCollectionPerformance,
-    trackComponents: dataCollectionPerformance ? trackedComponents : false,
+    trackComponents: false,
 
     integrations,
   })

--- a/website/src/registerServiceWorker.ts
+++ b/website/src/registerServiceWorker.ts
@@ -35,7 +35,7 @@ export default function registerServiceWorker(router: Router) {
       if (!registration) return
 
       // Routinely check for app updates by testing for a new service worker
-      setInterval(() => registration.update(), 60 * 60 * 1000)
+      setInterval(() => registration.update().catch(() => {}), 60 * 60 * 1000)
     },
 
     onNeedRefresh() {

--- a/website/src/stores/food.ts
+++ b/website/src/stores/food.ts
@@ -12,6 +12,7 @@ export interface Menu {
     fruitvegetable: string | null
   } | null
   lunch: {
+    until: string | null
     normal: string | null
     vegetarian: string | null
   } | null

--- a/website/src/stores/food.ts
+++ b/website/src/stores/food.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 
-import { getCurrentDate, getISODate, getWeekdays } from '@/utils/days'
+import { getCurrentDate, getISODate } from '@/utils/days'
 import { updateWrapper } from '@/utils/update'
 
 export interface Menu {
@@ -35,25 +35,17 @@ export const useFoodStore = defineStore('food', {
   actions: {
     async updateMenus() {
       await updateWrapper(async () => {
-        this.menus = await Promise.all(
-          getWeekdays(getCurrentDate()).map(async (date): Promise<Menu> => {
-            const iso = getISODate(date)
-            const response = await fetch(import.meta.env.VITE_API + '/menus/date/' + iso)
-            return { ...(await response.json()), date: iso }
-          }),
-        )
+        const date = getISODate(getCurrentDate())
+        const response = await fetch(import.meta.env.VITE_API + '/menus/week/' + date)
+        this.menus = await response.json()
       })
     },
 
     async updateLunchSchedules() {
       await updateWrapper(async () => {
-        this.lunchSchedules = await Promise.all(
-          getWeekdays(getCurrentDate()).map(async (date): Promise<LunchSchedule[]> => {
-            const iso = getISODate(date)
-            const response = await fetch(import.meta.env.VITE_API + '/schedule/date/' + iso)
-            return await response.json()
-          }),
-        )
+        const date = getISODate(getCurrentDate())
+        const response = await fetch(import.meta.env.VITE_API + '/schedule/week/' + date)
+        this.lunchSchedules = await response.json()
       })
     },
   },

--- a/website/src/stores/lists.ts
+++ b/website/src/stores/lists.ts
@@ -14,15 +14,11 @@ export const useListsStore = defineStore('lists', {
   actions: {
     async updateLists() {
       await updateWrapper(async () => {
-        const responses = await Promise.all([
-          fetch(import.meta.env.VITE_API + '/list/classes'),
-          fetch(import.meta.env.VITE_API + '/list/teachers'),
-          fetch(import.meta.env.VITE_API + '/list/classrooms'),
+        const [classesList, teachersList, classroomsList] = await Promise.all([
+          fetch(import.meta.env.VITE_API + '/list/classes').then(response => response.json()),
+          fetch(import.meta.env.VITE_API + '/list/teachers').then(response => response.json()),
+          fetch(import.meta.env.VITE_API + '/list/classrooms').then(response => response.json()),
         ])
-
-        const [classesList, teachersList, classroomsList] = await Promise.all(
-          responses.map(response => response.json()),
-        )
 
         this.classesList = sortEntities(EntityType.Class, classesList)
         this.teachersList = sortEntities(EntityType.Teacher, teachersList)

--- a/website/src/stores/timetable.ts
+++ b/website/src/stores/timetable.ts
@@ -63,6 +63,8 @@ export const useTimetableStore = defineStore('timetable', {
         return []
       }
 
+      performance.mark('lessons.start')
+
       let timetable: Lesson[] = []
       let substitutions: Substitution[] = []
 
@@ -176,6 +178,9 @@ export const useTimetableStore = defineStore('timetable', {
           }
         }
       }
+
+      performance.mark('lessons.end')
+      performance.measure('lessons', 'lessons.start', 'lessons.end')
 
       return array
     },

--- a/website/src/stores/timetable.ts
+++ b/website/src/stores/timetable.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia'
 
 import { useSessionStore } from '@/stores/session'
 import { EntityType, useSettingsStore } from '@/stores/settings'
-import { getCurrentDate, getISODate, getWeekdays } from '@/utils/days'
+import { getCurrentDate, getISODate } from '@/utils/days'
 import { updateWrapper } from '@/utils/update'
 
 export interface Lesson {
@@ -196,10 +196,9 @@ export const useTimetableStore = defineStore('timetable', {
 
     async updateSubstitutions() {
       await updateWrapper(async () => {
-        const dates = getWeekdays(getCurrentDate()).map(date => getISODate(date))
-        const urls = dates.map(date => import.meta.env.VITE_API + '/substitutions/date/' + date)
-        const responses = await Promise.all(urls.map(url => fetch(url)))
-        this.substitutions = await Promise.all(responses.map(response => response.json()))
+        const date = getISODate(getCurrentDate())
+        const response = await fetch(import.meta.env.VITE_API + '/substitutions/week/' + date)
+        this.substitutions = await response.json()
       })
     },
 

--- a/website/src/views/ViewTimetable.vue
+++ b/website/src/views/ViewTimetable.vue
@@ -6,17 +6,19 @@ import { useDisplay } from 'vuetify'
 import TimetableDetails from '@/components/TimetableDetails.vue'
 import TimetableDisplay from '@/components/TimetableDisplay.vue'
 import { useSessionStore } from '@/stores/session'
+import { EntityType } from '@/stores/settings'
 import { type MergedLesson, useTimetableStore } from '@/stores/timetable'
 import { localizedWeekdays } from '@/utils/localization'
 
 const { mobile } = useDisplay()
 
-const { day } = storeToRefs(useSessionStore())
+const { currentEntityType, day } = storeToRefs(useSessionStore())
+const { updateTimetable, updateSubstitutions, updateEmptyClassrooms } = useTimetableStore()
 
-const timetableStore = useTimetableStore()
-timetableStore.updateTimetable()
-timetableStore.updateSubstitutions()
-timetableStore.updateEmptyClassrooms()
+updateTimetable()
+updateSubstitutions()
+
+if (currentEntityType === EntityType.EmptyClassrooms) updateEmptyClassrooms()
 
 const detailsDialog = ref(false)
 const detailsProps = ref({ day: -1, time: -1, lessons: [] as MergedLesson[] })

--- a/website/src/views/ViewTimetable.vue
+++ b/website/src/views/ViewTimetable.vue
@@ -18,7 +18,7 @@ const { updateTimetable, updateSubstitutions, updateEmptyClassrooms } = useTimet
 updateTimetable()
 updateSubstitutions()
 
-if (currentEntityType === EntityType.EmptyClassrooms) updateEmptyClassrooms()
+if (currentEntityType.value === EntityType.EmptyClassrooms) updateEmptyClassrooms()
 
 const detailsDialog = ref(false)
 const detailsProps = ref({ day: -1, time: -1, lessons: [] as MergedLesson[] })

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -106,7 +106,7 @@ export default defineConfig(({ mode }) => {
     Vuetify(),
     Html(htmlConfig),
     VitePWA(pwaConfig),
-    ApachePreload(preloadConfig)
+    ApachePreload(preloadConfig),
   ]
 
   // Upload sourcemaps for the current release to Sentry if enabled
@@ -144,6 +144,8 @@ export default defineConfig(({ mode }) => {
       'import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE': parseFloat(env.VITE_SENTRY_TRACES_SAMPLE_RATE) || 0,
       'import.meta.env.VITE_SENTRY_PROFILES_SAMPLE_RATE': parseFloat(env.VITE_SENTRY_PROFILES_SAMPLE_RATE) || 0,
       'import.meta.env.VITE_SENTRY_TRACE_PROPAGATION_TARGETS': env.VITE_SENTRY_TRACE_PROPAGATION_TARGETS?.split(','),
+      // Disable Sentry debug mode in production
+      '__SENTRY_DEBUG__': mode === 'production' ? 'false' : 'true',
     },
 
     build: {


### PR DESCRIPTION
This PR implements various improvements and fixes for frontend and backend.

A notable change is that there are new per-week routes for substitutions, menus and lunch schedules. They accept a date and return the data for all weekdays in the week containing the given date. If the given date is a weekend, the data for the next week are returned, The data are returned in a list, with one entry per day (Monday-Friday).

Additionally, a new `until` field has been added to the lunch menu. This is currently unused, but will be used in the future to store the lunch until value in the menu updater and display it in the frontend.

As a result, this PR introduces a backward incompatible change. A new nullable time `until` field has been added to the `lunch_menu` table. You need to manually add it or recreate the database.