### PR TITLE
Fixes for timetable and lunch schedule parsers

### DIFF
--- a/API/gimvicurnik/blueprints/schedule.py
+++ b/API/gimvicurnik/blueprints/schedule.py
@@ -35,7 +35,7 @@ class ScheduleHandler(BaseHandler):
 
             query = (
                 Session.query(LunchSchedule, Class.name)
-                .join(Class)
+                .join(Class, isouter=True)
                 .filter(LunchSchedule.date == date)
                 .order_by(LunchSchedule.time, LunchSchedule.class_)
             )
@@ -53,7 +53,7 @@ class ScheduleHandler(BaseHandler):
 
             query = (
                 Session.query(LunchSchedule, Class.name)
-                .join(Class)
+                .join(Class, isouter=True)
                 .filter(LunchSchedule.date.in_(weekdays))
                 .order_by(LunchSchedule.time, LunchSchedule.class_)
             )

--- a/API/gimvicurnik/database/__init__.py
+++ b/API/gimvicurnik/database/__init__.py
@@ -100,7 +100,7 @@ class Entity:
     ) -> Iterator[dict[str, Any]]:
         query = (
             Session.query(Lesson, Class.name, Teacher.name, Classroom.name)
-            .join(Class)
+            .join(Class, isouter=True)
             .join(Teacher, isouter=True)
             .join(Classroom, isouter=True)
             .order_by(Lesson.day, Lesson.time)
@@ -134,7 +134,7 @@ class Entity:
         # fmt: off
         query = (
             Session.query(Substitution, Class.name, original_teacher.name, original_classroom.name, teacher.name, classroom.name)
-            .join(Class)
+            .join(Class, isouter=True)
             .join(original_teacher, Substitution.original_teacher_id == original_teacher.id, isouter=True)
             .join(original_classroom, Substitution.original_classroom_id == original_classroom.id, isouter=True)
             .join(teacher, Substitution.teacher_id == teacher.id, isouter=True)
@@ -216,8 +216,8 @@ class Lesson(Base):
     time: Mapped[smallint]
     subject: Mapped[text | None]
 
-    class_id: Mapped[class_fk] = mapped_column(index=True)
-    class_: Mapped[Class] = relationship(backref="lessons")
+    class_id: Mapped[class_fk | None] = mapped_column(index=True)
+    class_: Mapped[Class | None] = relationship(backref="lessons")
 
     teacher_id: Mapped[teacher_fk | None] = mapped_column(index=True)
     teacher: Mapped[Teacher | None] = relationship(backref="lessons")
@@ -244,8 +244,8 @@ class Substitution(Base):
     original_classroom_id: Mapped[classroom_fk | None] = mapped_column(index=True)
     original_classroom: Mapped[Classroom | None] = relationship(foreign_keys=[original_classroom_id])
 
-    class_id: Mapped[class_fk] = mapped_column(index=True)
-    class_: Mapped[Class] = relationship(backref="substitutions", foreign_keys=[class_id])
+    class_id: Mapped[class_fk | None] = mapped_column(index=True)
+    class_: Mapped[Class | None] = relationship(backref="substitutions", foreign_keys=[class_id])
 
     teacher_id: Mapped[teacher_fk | None] = mapped_column(index=True)
     teacher: Mapped[Teacher | None] = relationship(backref="substitutions", foreign_keys=[teacher_id])
@@ -262,8 +262,8 @@ class LunchSchedule(Base):
     date: Mapped[date_] = mapped_column(index=True)
     time: Mapped[time_ | None]
 
-    class_id: Mapped[class_fk] = mapped_column(index=True)
-    class_: Mapped[Class] = relationship()
+    class_id: Mapped[class_fk | None] = mapped_column(index=True)
+    class_: Mapped[Class | None] = relationship()
 
     location: Mapped[text | None]
     notes: Mapped[text | None]

--- a/API/gimvicurnik/updaters/timetable.py
+++ b/API/gimvicurnik/updaters/timetable.py
@@ -126,7 +126,6 @@ class TimetableUpdater:
                 "classroom_id": get_or_create(self.session, model=Classroom, name=lesson[4])[0].id if lesson[4] else None,
             }
             for _, lesson in lessons.items()
-            if lesson[1]
         ]
         # fmt: on
 

--- a/API/gimvicurnik/updaters/timetable.py
+++ b/API/gimvicurnik/updaters/timetable.py
@@ -16,6 +16,7 @@ from ..utils.database import get_or_create
 from ..utils.sentry import sentry_available, with_span
 
 if typing.TYPE_CHECKING:
+    from typing import Any
     from sqlalchemy.orm import Session
     from sentry_sdk.tracing import Span
     from ..config import ConfigSourcesTimetable
@@ -114,36 +115,49 @@ class TimetableUpdater:
         for key, value in data:
             lessons[key].append(value.strip())
 
+        models: list[dict[str, Any]] = []
+
         # Convert raw data into a model
-        # fmt: off
-        models = [
-            {
-                "day": lesson[5],
-                "time": lesson[6],
-                "subject": lesson[3] if lesson[3] else None,
-                "class_id": get_or_create(self.session, model=Class, name=lesson[1])[0].id if lesson[1] else None,
-                "teacher_id": get_or_create(self.session, model=Teacher, name=lesson[2])[0].id if lesson[2] else None,
-                "classroom_id": get_or_create(self.session, model=Classroom, name=lesson[4])[0].id if lesson[4] else None,
-            }
-            for _, lesson in lessons.items()
-        ]
-        # fmt: on
+        for lesson in lessons.values():
+            # Each cell may contain multiple values separated by a tilde
+            classes = lesson[1].split("~") if lesson[1] else [None]
+            teachers = lesson[2].split("~") if lesson[2] else [None]
+            classrooms = lesson[4].split("~") if lesson[4] else [None]
+
+            # fmt: off
+            models.extend(
+                {
+                    "day": lesson[5],
+                    "time": lesson[6],
+                    "subject": lesson[3] if lesson[3] else None,
+                    "class_id": get_or_create(self.session, model=Class, name=class_)[0].id if class_ else None,
+                    "teacher_id": get_or_create(self.session, model=Teacher, name=teacher)[0].id if teacher else None,
+                    "classroom_id": get_or_create(self.session, model=Classroom, name=classroom)[0].id if classroom else None,
+                }
+                for class_ in classes
+                for teacher in teachers
+                for classroom in classrooms
+            )
+            # fmt: on
 
         # Store timetable lessons
         self.session.query(Lesson).delete()
         self.session.execute(insert(Lesson), models)
 
         # Store a list of all classes from timetable
-        for class_ in re.findall(r"razredi\[\d+] = \"([^\"\n]*)\"", raw_data, re.MULTILINE):
-            get_or_create(self.session, model=Class, name=class_)
+        for classes in re.findall(r"razredi\[\d+] = \"([^\"\n]*)\"", raw_data, re.MULTILINE):
+            for class_ in classes.split("~"):
+                get_or_create(self.session, model=Class, name=class_)
 
         # Store a list of all teachers from timetable
-        for teacher in re.findall(r"ucitelji\[\d+] = \"([^\"\n]*)\"", raw_data, re.MULTILINE):
-            get_or_create(self.session, model=Teacher, name=teacher)
+        for teachers in re.findall(r"ucitelji\[\d+] = \"([^\"\n]*)\"", raw_data, re.MULTILINE):
+            for teacher in teachers.split("~"):
+                get_or_create(self.session, model=Teacher, name=teacher)
 
         # Store a list of all classrooms from timetable
-        for classroom in re.findall(r"ucilnice\[\d+] = \"([^\"\n]*)\"", raw_data, re.MULTILINE):
-            get_or_create(self.session, model=Classroom, name=classroom)
+        for classrooms in re.findall(r"ucilnice\[\d+] = \"([^\"\n]*)\"", raw_data, re.MULTILINE):
+            for classroom in classrooms.split("~"):
+                get_or_create(self.session, model=Classroom, name=classroom)
 
         # Update or create a document
         if not document:

--- a/website/src/components/MenuDisplay.vue
+++ b/website/src/components/MenuDisplay.vue
@@ -32,7 +32,7 @@ const lunchMenu = computed(() => props.menu?.lunch?.[lunchType.value])
     <template #text>
       <div
         v-for="lunchSchedule in lunchSchedules"
-        :key="lunchSchedule.time + lunchSchedule.class"
+        :key="`${lunchSchedule.date}-${lunchSchedule.time}-${lunchSchedule.class}-${lunchSchedule.location}`"
         class="pb-2"
       >
         <div v-if="lunchSchedule.time">Ura: {{ lunchSchedule.time }}</div>

--- a/website/src/stores/food.ts
+++ b/website/src/stores/food.ts
@@ -19,9 +19,9 @@ export interface Menu {
 }
 
 export interface LunchSchedule {
-  class: string
   date: string
   time: string | null
+  class: string | null
   notes: string | null
   location: string | null
 }

--- a/website/src/views/ViewMenu.vue
+++ b/website/src/views/ViewMenu.vue
@@ -21,7 +21,7 @@ updateLunchSchedules()
 
 function entitiesLunchSchedules(lunchSchedules?: LunchSchedule[]) {
   if (!lunchSchedules || entityType.value !== EntityType.Class) return []
-  return lunchSchedules.filter(schedule => entityList.value.includes(schedule.class))
+  return lunchSchedules.filter(schedule => entityList.value.includes(schedule.class!))
 }
 
 // Stop stopping event propagation on touch handlers


### PR DESCRIPTION
This PR contains fixes  for timetable and lunch schedule parsers.

It also introduces a backward incompatible change. The `class_id` fields in the `lessons`, `substitutions` and `lunch_schedule` tables are now nullable. You need to manually change this or recreate the database.